### PR TITLE
[UDT-75] 추천 페이지 및 엄선된 콘텐츠 페이지 연결 및 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@radix-ui/react-avatar": "^1.1.10",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-radio-group": "^1.3.7",
         "@radix-ui/react-slot": "^1.2.3",
@@ -31,6 +32,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@next/eslint-plugin-next": "^15.3.5",
         "@storybook/addon-docs": "^9.0.15",
         "@storybook/addon-links": "^9.0.16",
         "@storybook/addon-onboarding": "^9.0.15",
@@ -3432,6 +3434,42 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
@@ -3443,6 +3481,73 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
+      "integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
+      "integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3472,6 +3577,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3657,6 +3786,24 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -5705,6 +5852,18 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
@@ -7269,6 +7428,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.3",
@@ -8900,6 +9065,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -12299,6 +12473,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -14305,6 +14548,49 @@
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/use-sync-external-store": {
       "version": "1.5.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
           {/* 외부 컨테이너 - 큰 화면에서 다른 배경색 */}
           <div className="min-h-screen bg-gray-100 flex justify-center overflow-hidden">
             {/* 앱 컨테이너 - 고정 너비 */}
-            <div className="w-full max-w-150 bg-primary-800 text-white h-screen flex flex-col relative overflow-hidden">
+            <div className="w-full max-w-160 bg-primary-800 text-white h-screen flex flex-col relative overflow-hidden">
               <main className="flex flex-1 flex-col overflow-y-auto pb-[57px]">
                 {children}
               </main>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,8 +29,8 @@ export default function RootLayout({
           {/* 외부 컨테이너 - 큰 화면에서 다른 배경색 */}
           <div className="min-h-screen bg-gray-100 flex justify-center overflow-hidden">
             {/* 앱 컨테이너 - 고정 너비 */}
-            <div className="w-full max-w-160 bg-primary-800 text-white min-h-screen relative overflow-hidden">
-              <main className="pb-20 min-h-screen overflow-y-auto">
+            <div className="w-full max-w-150 bg-primary-800 text-white h-screen flex flex-col relative overflow-hidden">
+              <main className="flex flex-1 flex-col overflow-y-auto pb-[57px]">
                 {children}
               </main>
               <BottomNavbar />

--- a/src/app/recommendation/page.tsx
+++ b/src/app/recommendation/page.tsx
@@ -171,12 +171,6 @@ export default function MovieSwipePage() {
   // 메인 UI 렌더링
   return (
     <div className="flex flex-1 flex-col items-center justify-center">
-      {/* 진행 표시기 */}
-      <div className="my-3 text-white text-center">
-        <div className="text-sm opacity-80">
-          {currentIndex + 1} / {dummyMovies.length}
-        </div>
-      </div>
       {/* 카드 컨테이너 */}
       <div className="my-4 flex w-full justify-center">
         <div
@@ -200,7 +194,7 @@ export default function MovieSwipePage() {
           }}
         >
           {/* 보이지 않는 자리 채우기용 티켓 */}
-          <div className="relative flex w-full aspect-[75/135] invisible pointer-events-none items-center justify-center">
+          <div className="relative flex w-full aspect-[75/135] max-w-100 max-h-180 invisible pointer-events-none items-center justify-center">
             <Ticket movie={currentMovie} variant="initial" feedback="neutral" />
           </div>
           {/* ── 다음 카드(peek) ── */}

--- a/src/app/recommendation/page.tsx
+++ b/src/app/recommendation/page.tsx
@@ -170,17 +170,17 @@ export default function MovieSwipePage() {
 
   // 메인 UI 렌더링
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4">
+    <div className="flex flex-1 flex-col items-center justify-center">
       {/* 진행 표시기 */}
-      <div className="mb-6 text-white text-center">
+      <div className="my-3 text-white text-center">
         <div className="text-sm opacity-80">
           {currentIndex + 1} / {dummyMovies.length}
         </div>
       </div>
       {/* 카드 컨테이너 */}
-      <div className="mb-8 flex justify-center">
+      <div className="my-4 flex w-full justify-center">
         <div
-          className={`relative inline-block select-none ${
+          className={`relative inline-block mx-10 justify-center w-full select-none ${
             isFlipped ? 'touch-action-auto' : 'touch-action-none'
           }`}
           onPointerDown={(e) => {
@@ -200,14 +200,14 @@ export default function MovieSwipePage() {
           }}
         >
           {/* 보이지 않는 자리 채우기용 티켓 */}
-          <div className="invisible pointer-events-none">
+          <div className="relative flex w-full aspect-[75/135] invisible pointer-events-none items-center justify-center">
             <Ticket movie={currentMovie} variant="initial" feedback="neutral" />
           </div>
           {/* ── 다음 카드(peek) ── */}
           {nextMovie && (
             <div
               className={`
-                absolute inset-0 z-10 opacity-50 blur-sm
+                absolute inset-0 z-10 flex items-center justify-center opacity-50 blur-sm
                 pointer-events-none
                 transition-transform duration-200 linear
                 ${
@@ -224,6 +224,7 @@ export default function MovieSwipePage() {
           <div
             className={`
               absolute inset-0 z-20
+              flex items-center justify-center
               ${
                 swipeDirection
                   ? // → 스와이프 transform: 700ms 동안 천천히 translate/rotate
@@ -257,7 +258,7 @@ export default function MovieSwipePage() {
               >
                 {/* Front side */}
                 <div
-                  className={`absolute inset-0 transition-opacity duration-300 ${
+                  className={`absolute inset-0 flex justify-center items-center transition-opacity duration-300 ${
                     isFlipped ? 'opacity-0' : 'opacity-100'
                   }`}
                   style={{ backfaceVisibility: 'hidden' }}
@@ -270,7 +271,7 @@ export default function MovieSwipePage() {
                 </div>
                 {/* Back side */}
                 <div
-                  className={`absolute inset-0 transition-opacity duration-300 ${
+                  className={`absolute inset-0 flex justify-center items-center transition-opacity duration-300 ${
                     isFlipped ? 'opacity-100' : 'opacity-0'
                   }`}
                   style={{
@@ -287,7 +288,7 @@ export default function MovieSwipePage() {
           </div>
         </div>
       </div>
-      <div className="relative z-30 flex flex-col items-center gap-4 mt-4">
+      <div className="relative z-30 flex flex-col items-center gap-4">
         <Button
           onClick={() => setIsFlipped(!isFlipped)}
           variant="outline"

--- a/src/app/recommendation/result/page.tsx
+++ b/src/app/recommendation/result/page.tsx
@@ -1,15 +1,14 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { RefreshCw } from 'lucide-react';
+import React, { useState, useEffect } from 'react';
+import { RefreshCw, Eye, EyeOff, Plus } from 'lucide-react';
+import { motion, type PanInfo } from 'framer-motion';
 import { Ticket } from '@components/Ticket/Ticket';
 import type { MovieData } from '@type/Moviedata';
-import { Button } from '@components/ui/button';
-import { dummyMovies } from './../moviedata';
+import { Button } from '@/components/ui/button';
+import { dummyMovies } from '../moviedata';
 
-// Mock data generator
-
-const RecommendationResults = () => {
+const RecommendationResults: React.FC = () => {
   const [movies, setMovies] = useState<MovieData[]>([]);
   const [rerollUsed, setRerollUsed] = useState<boolean[]>([
     false,
@@ -17,11 +16,16 @@ const RecommendationResults = () => {
     false,
   ]);
   const [isLoading, setIsLoading] = useState(true);
+  const [currentIndex, setCurrentIndex] = useState(1); // 가운데부터 시작
+  const [showDetails, setShowDetails] = useState<boolean[]>([
+    false,
+    false,
+    false,
+  ]);
 
   // Initialize movies after loading
   useEffect(() => {
     const timer = setTimeout(() => {
-      // dummyMovies[0], [1], [2] 만 가져와서 보여줌
       setMovies(dummyMovies.slice(0, 3));
       setIsLoading(false);
     }, 3000);
@@ -29,18 +33,49 @@ const RecommendationResults = () => {
   }, []);
 
   const handleReroll = (index: number) => {
-    // 이미 리롤했거나, 데이터 개수가 충분치 않으면 무시
     if (rerollUsed[index] || movies.length < 3 || dummyMovies.length < 6)
       return;
 
     const newMovies = [...movies];
-    // index 0→dummyMovies[3], 1→[4], 2→[5]
     newMovies[index] = dummyMovies[index + 3];
     setMovies(newMovies);
 
     const newUsed = [...rerollUsed];
     newUsed[index] = true;
     setRerollUsed(newUsed);
+  };
+
+  const toggleDetails = (index: number) => {
+    const newShow = [...showDetails];
+    newShow[index] = !newShow[index];
+    setShowDetails(newShow);
+  };
+
+  const handleAddContent = () => {
+    const movie = movies[currentIndex];
+    if (movie) {
+      console.log('추가된 콘텐츠 ID:', movie.contentId);
+      console.log('추가된 콘텐츠 정보:', movie);
+    }
+  };
+
+  const handleDragEnd = (_: unknown, info: PanInfo) => {
+    const threshold = 50;
+    if (info.offset.x > threshold && currentIndex > 0) {
+      setCurrentIndex(currentIndex - 1);
+    } else if (info.offset.x < -threshold && currentIndex < movies.length - 1) {
+      setCurrentIndex(currentIndex + 1);
+    }
+  };
+
+  const getCardPosition = (index: number) => {
+    const diff = index - currentIndex;
+    return {
+      x: diff * 300,
+      scale: diff === 0 ? 1 : 0.8,
+      opacity: diff === 0 ? 1 : 0.6,
+      zIndex: diff === 0 ? 10 : 1,
+    };
   };
 
   if (isLoading) {
@@ -61,7 +96,7 @@ const RecommendationResults = () => {
           ))}
         </div>
 
-        {/* Main content */}
+        {/* Main loading content */}
         <div className="text-center text-white z-10">
           <div
             className="mb-8 animate-fade-in-up"
@@ -81,7 +116,6 @@ const RecommendationResults = () => {
           {/* Animated crescent moon formation */}
           <div className="mb-8 flex justify-center">
             <div className="relative w-20 h-20">
-              {/* Moon particles gathering */}
               {[...Array(8)].map((_, i) => (
                 <div
                   key={i}
@@ -95,7 +129,6 @@ const RecommendationResults = () => {
                 />
               ))}
 
-              {/* Final moon shape */}
               <div
                 className="absolute inset-0 opacity-0 animate-moon-form"
                 style={{ animationDelay: '4s' }}
@@ -135,37 +168,113 @@ const RecommendationResults = () => {
   }
 
   return (
-    <div className="min-h-screen p-6">
-      <div className="max-w-4xl mx-auto">
-        <div className="text-center mb-8">
-          <h1 className="text-2xl font-bold mb-2">추천 결과</h1>
+    <div className="min-h-full p-6 flex items-center justify-center">
+      <div className="w-full">
+        <div className="text-center mb-4">
+          <h1 className="text-3xl font-bold mb-2">추천 결과</h1>
           <p className="text-gray-600">마음에 드는 컨텐츠를 선택해보세요</p>
         </div>
+        {/* Carousel Container (높이 고정) */}
+        <div className="relative h-[600px] py-5 flex items-center justify-center">
+          <div className="flex items-center justify-center">
+            {movies.map((movie, index) => {
+              const pos = getCardPosition(index);
+              const isCenter = index === currentIndex;
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {movies.map((movie, index) => (
-            <div
-              key={movie.contentId}
-              className="relative animate-bounce-in"
-              style={{ animationDelay: `${index * 0.2}s` }}
-            >
-              <Ticket movie={movie} variant="result" />
+              return (
+                <motion.div
+                  key={movie.contentId}
+                  className="absolute w-80 h-full flex flex-col items-center overflow-visible"
+                  drag="x"
+                  dragConstraints={{ left: -300, right: 300 }}
+                  dragElastic={0}
+                  onDragEnd={handleDragEnd}
+                  animate={{
+                    x: pos.x,
+                    scale: pos.scale,
+                    opacity: pos.opacity,
+                    zIndex: pos.zIndex,
+                  }}
+                  transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                >
+                  {/* Ticket을 flex-1 래퍼로 감싸서 부모 높이 전파 */}
+                  <div className="relative flex-1 w-full">
+                    <Ticket
+                      movie={movie}
+                      variant={showDetails[index] ? 'detail' : 'result'}
+                      feedback="neutral"
+                    />
+                  </div>
 
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => handleReroll(index)}
-                disabled={rerollUsed[index]}
-                className={`absolute -top-2 -right-2 w-8 h-8 p-0 bg-white shadow-md hover:shadow-lg transition-all ${
-                  rerollUsed[index]
-                    ? 'opacity-50 cursor-not-allowed'
-                    : 'hover:scale-110'
-                }`}
-              >
-                <RefreshCw className={`w-4 h-4`} />
-              </Button>
-            </div>
+                  {/* 중앙 카드에만 보여질 컨트롤 버튼 */}
+                  {isCenter && (
+                    <motion.div
+                      className="absolute -top-2 -right-2 flex gap-2 z-50"
+                      initial={{ opacity: 0, scale: 0.8 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      transition={{ duration: 0.3, ease: 'linear' }}
+                    >
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => toggleDetails(index)}
+                        className="w-8 h-8 p-0 bg-white shadow-md hover:shadow-lg transition-all hover:scale-110"
+                      >
+                        {showDetails[index] ? (
+                          <EyeOff className="w-4 h-4 text-black" />
+                        ) : (
+                          <Eye className="w-4 h-4 text-black" />
+                        )}
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleReroll(index)}
+                        disabled={rerollUsed[index]}
+                        className={`w-8 h-8 p-0 bg-white shadow-md transition-all ${
+                          rerollUsed[index]
+                            ? 'opacity-50 cursor-not-allowed'
+                            : 'hover:shadow-lg hover:scale-110'
+                        }`}
+                      >
+                        <RefreshCw
+                          className={`w-4 h-4 ${
+                            rerollUsed[index] ? 'text-gray-60' : 'text-black'
+                          } `}
+                        />
+                      </Button>
+                    </motion.div>
+                  )}
+                </motion.div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Navigation dots */}
+        <div className="flex justify-center mt-8 space-x-2">
+          {movies.map((_, i) => (
+            <button
+              key={i}
+              onClick={() => setCurrentIndex(i)}
+              className={`w-3 h-3 rounded-full transition-all ${
+                i === currentIndex
+                  ? 'bg-blue-500 scale-125'
+                  : 'bg-gray-300 hover:bg-gray-400'
+              }`}
+            />
           ))}
+        </div>
+
+        {/* Add Content Button */}
+        <div className="flex justify-center mt-8">
+          <Button
+            onClick={handleAddContent}
+            className="px-8 py-3 bg-primary-600 hover:bg-primary-600 text-white rounded-full shadow-lg hover:shadow-xl transition-all duration-300 flex items-center gap-2"
+          >
+            <Plus className="w-5 h-5" />
+            <span className="font-medium">이 콘텐츠 추가하기</span>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/Ticket/Ticket.tsx
+++ b/src/components/Ticket/Ticket.tsx
@@ -33,8 +33,8 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'detail') {
     return (
-      <Card className="flex flex-col w-full h-full min-w-60 min-h-108 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
-        <div className="relative w-full h-[30%] border-b border-border overflow-hidden">
+      <Card className="flex flex-col w-full h-full min-w-70 min-h-126 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+        <div className="relative flex-grow">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}
             alt={movie.title}
@@ -131,8 +131,8 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'result') {
     return (
-      <Card className="flex flex-col w-full h-full min-w-60 min-h-108 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
-        <div className="relative w-75 h-100 border-b border-border overflow-hidden">
+      <Card className="flex flex-col w-full h-full min-w-70 min-h-126 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+        <div className="relative flex-grow">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}
             alt={movie.title}
@@ -170,7 +170,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'initial') {
     return (
-      <Card className="flex flex-col w-full h-full min-w-60 min-h-108 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+      <Card className="flex flex-col w-full h-full min-w-70 min-h-126 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
         <div className="relative flex-grow">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}

--- a/src/components/Ticket/Ticket.tsx
+++ b/src/components/Ticket/Ticket.tsx
@@ -33,8 +33,8 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'detail') {
     return (
-      <Card className="w-75 h-135 border-border max-w-sm flex flex-col rounded-2xl overflow-hidden">
-        <div className="relative w-75 h-32.5 border-b border-border overflow-hidden">
+      <Card className="flex flex-col w-full h-full min-w-75 min-h-135 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+        <div className="relative w-full h-[30%] border-b border-border overflow-hidden">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}
             alt={movie.title}
@@ -131,7 +131,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'result') {
     return (
-      <Card className="w-75 h-135 border-border max-w-sm flex flex-col rounded-2xl overflow-hidden">
+      <Card className="flex flex-col w-full h-full min-w-75 min-h-135 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
         <div className="relative w-75 h-100 border-b border-border overflow-hidden">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}
@@ -170,7 +170,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'initial') {
     return (
-      <Card className="flex flex-col w-75 h-135 overflow-hidden group cursor-pointer transition-transform duration-500">
+      <Card className="flex flex-col w-full h-full min-w-75 min-h-135 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
         <div className="relative flex-grow">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}

--- a/src/components/Ticket/Ticket.tsx
+++ b/src/components/Ticket/Ticket.tsx
@@ -33,7 +33,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'detail') {
     return (
-      <Card className="flex flex-col w-full h-full min-w-75 min-h-135 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+      <Card className="flex flex-col w-full h-full min-w-60 min-h-108 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
         <div className="relative w-full h-[30%] border-b border-border overflow-hidden">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}
@@ -131,7 +131,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'result') {
     return (
-      <Card className="flex flex-col w-full h-full min-w-75 min-h-135 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+      <Card className="flex flex-col w-full h-full min-w-60 min-h-108 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
         <div className="relative w-75 h-100 border-b border-border overflow-hidden">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}
@@ -170,7 +170,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'initial') {
     return (
-      <Card className="flex flex-col w-full h-full min-w-75 min-h-135 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+      <Card className="flex flex-col w-full h-full min-w-60 min-h-108 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
         <div className="relative flex-grow">
           <Image
             src={movie.posterUrl || '/placeholder.svg'}

--- a/src/components/common/bottom-navbar.tsx
+++ b/src/components/common/bottom-navbar.tsx
@@ -34,7 +34,7 @@ export default function BottomNavbar() {
   const pathname = usePathname();
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 max-w-160 mx-auto bg-[var(--primary-900)]/50 backdrop-blur-md border-t border-[var(--primary-700)]/50 px-4 py-2 safe-area-pb">
+    <nav className="fixed bottom-0 left-0 right-0 z-50 max-w-160 mx-auto bg-[var(--primary-900)]/50 backdrop-blur-md border-t border-[var(--primary-700)]/50 px-4 safe-area-pb">
       <div className="flex justify-around items-center">
         {navItems.map((item) => {
           const Icon = item.icon;
@@ -44,14 +44,14 @@ export default function BottomNavbar() {
             <Link
               key={item.href}
               href={item.href}
-              className={`flex flex-col items-center justify-center p-3 rounded-xl transition-all duration-200 min-w-[60px] ${
+              className={`flex flex-col items-center justify-center p-2 rounded-xl transition-all duration-200 min-w-[60px] ${
                 isActive
                   ? 'text-white bg-[var(--primary-600)]/30'
                   : 'text-[var(--primary-200)] hover:text-white hover:bg-[var(--primary-700)]/20'
               }`}
             >
               <Icon
-                className={`w-6 h-6 mb-1 ${
+                className={`w-5 h-5 mb-1 ${
                   isActive ? 'text-white' : 'text-[var(--primary-200)]'
                 }`}
               />


### PR DESCRIPTION
## #️⃣연관된 이슈 

> UDT-75

## 📝작업 내용

 - Ticket 컴포넌트에서 max, min 사이즈 설정을 통해 뷰포트에 맞춰 동적으로 Ticket 사이즈를 설정할 수 있게 변경
 - 일부 스타일 속성 default 값 사용에서 변경
 - Ticket component 위치 항상 가운데로 올 수 있도록 변경 

### 스크린샷 

<img width="372" height="664" alt="image" src="https://github.com/user-attachments/assets/7bd7897b-759c-477a-978b-7d76636debdb" />

- 가장 작은 size인 iphone SE에 맞춰서 작아진 화면
- 추후에 상세 내용에서 더보기 했을 떄 통일된 스타일 때문에 더보기가 필요 없는 경우에도 줄이거나, 줄거리 파트 제외하고도 공간이 모자란데 더보기가 되지 않는 이유로 컨텐츠가 잘리는 현상 수정 필요

<img width="530" height="880" alt="image" src="https://github.com/user-attachments/assets/e4d34e75-cd92-4165-a470-476c559dede6" />

- Results 화면이며, Reroll 아이콘 버튼을 통해서 다른 컨텐츠로 교체 가능, 눈 아이콘 버튼을 통해 'detail' 속성으로 전환 가능
- 드래그를 통해서 옮길 수 있으며, reroll은 1번씩만 가능(총 3장+3장으로 6번)
- 하단의 추가하기 버튼을 통해서 contentId를 저장할 수 있는데, 지금은 console.log로만 되게 했음. 

## 💬리뷰 요구사항

> Reviewer가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
