### PR TITLE
[UDT-112] 탐색 페이지에서의 API 응답을 화면에 자연스럽게 표시하기 위한 리팩토링 진행

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,14 +1,13 @@
-version: '1'
-
-review:
-  summary: none # 요약 제거 (간단 요약도 안 함)
-  comments: inline # 필요한 부분에만 코멘트
-  language: ko # 한국어로 리뷰
-  diagrams: false # 시퀀스 다이어그램 같은 시각화 기능 꺼짐
-  tone: friendly # 친구처럼 자연스러운 말투 (선택 사항)
-
-cursor:
-  learn_from: ./cursor # 팀 컨벤션 학습 경로
-
-other_settings:
-  default: true # 나머지는 일반 PR 작성처럼
+# .coderabbit.yaml
+language: 'ko' # 리뷰 언어를 한국어로 설정
+early_access: false # 필요에 따라 설정
+tone_instructions: |
+  당신은 숙련된 코드 리뷰어입니다.
+  팀원이 남겨주는 것처럼 짧고 간결하게 피드백하세요.
+  문제와 해결 방안을 명확히 언급하며,
+  "이러한 이유 때문에 이렇게 고치면 좋을 것 같습니다" 형식으로 작성해 주세요.
+reviews:
+  profile: 'chill' # 기본 리뷰 프로필(예시)
+  request_changes_workflow: false
+  high_level_summary: true
+  # … 기타 설정

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,13 +1,34 @@
 # .coderabbit.yaml
-language: 'ko' # 리뷰 언어를 한국어로 설정
-early_access: false # 필요에 따라 설정
+language: 'ko-KR' # 한국어 리뷰
 tone_instructions: |
   당신은 숙련된 코드 리뷰어입니다.
   팀원이 남겨주는 것처럼 짧고 간결하게 피드백하세요.
   문제와 해결 방안을 명확히 언급하며,
   "이러한 이유 때문에 이렇게 고치면 좋을 것 같습니다" 형식으로 작성해 주세요.
+early_access: false # 얼리 액세스 기능 비활성화
+enable_free_tier: true # 무료 플랜 기능 활성화
+
 reviews:
-  profile: 'chill' # 기본 리뷰 프로필(예시)
+  profile: 'chill' # 부드러운 톤
   request_changes_workflow: false
-  high_level_summary: true
-  # … 기타 설정
+  high_level_summary: false # 상위 요약 비활성화
+  high_level_summary_in_walkthrough: false
+  changed_files_summary: false
+  sequence_diagrams: false # 시퀀스 다이어그램 비활성화
+  collapse_walkthrough: false
+  poem: false # 시(poem) 비활성화
+  estimate_code_review_effort: false
+  assess_linked_issues: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  auto_apply_labels: false
+
+chat:
+  auto_reply: true # 태그 없이도 자동 응답
+
+knowledge_base:
+  web_search:
+    enabled: true # 웹 검색 기능 활성화
+
+# 기타 설정은 기본값 유지

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from '@lib/utils';
+
+interface SkeletonProps {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+// 탐색 페이지에서 사용되는 공통 Skeleton 기본 컴포넌트
+export const Skeleton = ({ className, children }: SkeletonProps) => {
+  return (
+    <div className={cn('animate-pulse bg-gray-700/50 rounded-lg', className)}>
+      {children}
+    </div>
+  );
+};

--- a/src/components/explore/DetailBottomSheetContent.tsx
+++ b/src/components/explore/DetailBottomSheetContent.tsx
@@ -47,7 +47,7 @@ export const DetailBottomSheetContent = ({
   const [isSynopsisExpanded, setIsSynopsisExpanded] = useState(false); // 시놉시스(줄거리) 부분에 대해서 더 자세하게 보여주기 여부
   const [hasValidTrailer, setHasValidTrailer] = useState(true); // 트레일러 주소가 유효한지 여부
   const [isTextOverflowing, setIsTextOverflowing] = useState(false); // 텍스트가 5줄을 넘는지 여부
-  const [imgSrc, setImgSrc] = useState<string>(contentData.backdropUrl); // 백드랍 이미지 소스
+  const [imgSrc, setImgSrc] = useState<string>(contentData?.backdropUrl || ''); // 백드랍 이미지 소스
 
   if (isLoading) {
     return <div>로딩 중입니다.</div>;

--- a/src/components/explore/DetailBottomSheetContent.tsx
+++ b/src/components/explore/DetailBottomSheetContent.tsx
@@ -220,40 +220,50 @@ export const DetailBottomSheetContent = ({
         {/* 배우들 */}
         <div className="flex flex-col space-y-3">
           <span className="text-lg font-semibold text-white">출연진</span>
-          <div className="flex space-x-4 overflow-x-auto">
-            {contentData.casts.map((actor, index) => (
-              <div
-                key={index}
-                className="flex flex-col items-center space-y-2 min-w-[60px]"
-              >
-                <Avatar className="w-15 h-15 rounded-full overflow-hidden">
-                  <AvatarImage
-                    src={actor.image || '/placeholder.svg'}
-                    alt={actor.name}
-                    className="object-cover w-full h-full"
-                  />
-                  <AvatarFallback className="bg-gray-700 text-white">
-                    {actor.name.charAt(0)}
-                  </AvatarFallback>
-                </Avatar>
-                <span className="text-xs text-gray-300 text-center leading-tight">
-                  {actor.name}
-                </span>
-              </div>
-            ))}
-          </div>
+          {/* 출연진 정보가 있는 경우에만 표시 */}
+          {contentData.casts && contentData.casts.length > 0 ? (
+            <div className="flex space-x-4 overflow-x-auto">
+              {contentData.casts.map((actor, index) => (
+                <div
+                  key={index}
+                  className="flex flex-col items-center space-y-2 min-w-[60px]"
+                >
+                  <Avatar className="w-15 h-15 rounded-full overflow-hidden">
+                    <AvatarImage
+                      src={actor.castImage || '/placeholder.svg'}
+                      alt={actor.castName}
+                      className="object-cover w-full h-full"
+                    />
+                    <AvatarFallback className="bg-gray-700 text-2xl text-white size-full rounded-full flex items-center justify-center">
+                      {actor.castName.charAt(0)}
+                    </AvatarFallback>
+                  </Avatar>
+                  <span className="text-xs text-gray-300 text-center leading-tight">
+                    {actor.castName}
+                  </span>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <span className="text-sm text-gray-300">정보가 없습니다</span>
+          )}
         </div>
 
         {/* 감독 */}
         <div className="flex flex-col space-y-3">
           <span className="text-lg font-semibold text-white">감독</span>
-          <div className="flex flex-row items-center space-x-3">
-            {contentData.directors.map((director, index) => (
-              <span key={index} className="text-xs text-gray-300 text-center">
-                {director.name}
-              </span>
-            ))}
-          </div>
+          {/* 감독 정보가 있는 경우에만 표시 */}
+          {contentData.directors && contentData.directors.length > 0 ? (
+            <div className="flex flex-row items-center space-x-3">
+              {contentData.directors.map((director, index) => (
+                <span key={index} className="text-xs text-gray-300 text-center">
+                  {director.name}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <span className="text-sm text-gray-300">정보가 없습니다</span>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/explore/ExplorePageCarouselSkeleton.tsx
+++ b/src/components/explore/ExplorePageCarouselSkeleton.tsx
@@ -1,0 +1,86 @@
+// src/components/explore/CarouselSkeleton.tsx
+import { Skeleton } from '@components/common/Skeleton';
+
+const CARD_WIDTH = 272;
+const CARD_GAP = 8;
+const SCALE_FACTOR = 0.85;
+
+// 탐색 페이지 상단에 있는 큰 Carousel 스켈레톤 컴포넌트
+export const ExplorePageCarouselSkeleton = () => {
+  return (
+    <div className="w-full max-w-5xl mx-auto">
+      <div className="overflow-hidden">
+        <div
+          className="flex justify-center items-end"
+          style={{
+            transform: `translateX(0px)`,
+          }}
+        >
+          {/* 좌측 스케일된 카드 */}
+          <div
+            className="flex-shrink-0"
+            style={{
+              width: CARD_WIDTH,
+              marginRight: CARD_GAP,
+              transform: `scale(${SCALE_FACTOR})`,
+              transformOrigin: 'center bottom',
+            }}
+          >
+            <RepresentativeCardSkeleton dimmed />
+          </div>
+
+          {/* 중앙 메인 카드 */}
+          <div
+            className="flex-shrink-0"
+            style={{
+              width: CARD_WIDTH,
+              marginRight: CARD_GAP,
+              transform: 'scale(1)',
+              transformOrigin: 'center bottom',
+            }}
+          >
+            <RepresentativeCardSkeleton />
+          </div>
+
+          {/* 우측 스케일된 카드 */}
+          <div
+            className="flex-shrink-0"
+            style={{
+              width: CARD_WIDTH,
+              transform: `scale(${SCALE_FACTOR})`,
+              transformOrigin: 'center bottom',
+            }}
+          >
+            <RepresentativeCardSkeleton dimmed />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// RepresentativeContentCard와 동일한 구조의 Skeleton
+const RepresentativeCardSkeleton = ({
+  dimmed = false,
+}: {
+  dimmed?: boolean;
+}) => (
+  <div className={`relative w-68 h-87 ${dimmed ? 'opacity-40' : ''}`}>
+    {/* 메인 이미지 영역 */}
+    <Skeleton className="w-full h-full rounded-lg">
+      {/* 하단 그라데이션 영역 */}
+      <div className="absolute bottom-0 left-0 right-0 px-5 pb-5 flex flex-col items-center">
+        {/* 제목 Skeleton */}
+        <Skeleton className="w-40 h-6 mb-3 bg-gray-600/60" />
+
+        {/* 태그들 Skeleton */}
+        <div className="flex flex-wrap gap-1 justify-center">
+          <Skeleton className="w-12 h-5 bg-gray-600/60" />
+          <Skeleton className="w-16 h-5 bg-gray-600/60" />
+          <Skeleton className="w-14 h-5 bg-gray-600/60" />
+          <Skeleton className="w-10 h-5 bg-gray-600/60" />
+        </div>
+      </div>
+    </Skeleton>
+  </div>
+);

--- a/src/components/explore/PosterCardScrollBox.tsx
+++ b/src/components/explore/PosterCardScrollBox.tsx
@@ -10,6 +10,7 @@ import {
 import { DetailBottomSheetContent } from '@components/explore/DetailBottomSheetContent';
 import { useGetContentListByBoxType } from '@hooks/explore/useGetContentListByBoxType';
 import { FilterRadioButton } from '@components/explore/FilterRadioButton';
+import { PosterScrollSkeleton } from '@components/explore/PosterScrollBoxSkeleton';
 
 export interface PosterCardScrollBoxProps {
   BoxTitle: string;
@@ -27,7 +28,7 @@ export const PosterCardScrollBox = ({
   // 포스터 스크롤 박스 타입에 따라 콘텐츠 목록 조회 API 호출하는 custom Hook 호출
   const {
     data: contentData,
-    isError,
+    status,
     refetch,
   } = useGetContentListByBoxType(BoxType);
 
@@ -40,8 +41,13 @@ export const PosterCardScrollBox = ({
     refetch();
   };
 
+  // 로딩 중인 경우 (Skeleton UI 표시)
+  if (status === 'pending') {
+    return <PosterScrollSkeleton title={BoxTitle} count={8} />;
+  }
+
   // 에러 상태 또는 데이터가 없는 경우
-  if (isError || contentData.length === 0) {
+  if (status === 'error') {
     return (
       <div className="w-full h-fit flex flex-col justify-start items-start gap-2">
         <span className="text-xl text-white font-semibold py-2 ml-6">
@@ -49,9 +55,23 @@ export const PosterCardScrollBox = ({
         </span>
         <div className="w-full h-40 flex flex-col items-center justify-center gap-4 px-6">
           <span className="text-white text-lg text-center">
-            불러올 정보가 없습니다
+            오류가 발생했습니다.
           </span>
           <FilterRadioButton onToggle={handleRefetch} label="다시 불러오기" />
+        </div>
+      </div>
+    );
+  }
+
+  // 로딩은 성공 했으나, 데이터가 없는 경우
+  if (contentData.length === 0) {
+    return (
+      <div className="w-full h-fit flex flex-col justify-start items-start gap-2">
+        <span className="text-xl text-white font-semibold py-2 ml-6">
+          {BoxTitle}
+        </span>
+        <div className="w-full max-w-5xl mx-auto py-12 flex justify-center text-gray-300">
+          표시할 콘텐츠가 없습니다.
         </div>
       </div>
     );

--- a/src/components/explore/PosterCardScrollBox.tsx
+++ b/src/components/explore/PosterCardScrollBox.tsx
@@ -9,6 +9,7 @@ import {
 } from '@components/ui/sheet';
 import { DetailBottomSheetContent } from '@components/explore/DetailBottomSheetContent';
 import { useGetContentListByBoxType } from '@hooks/explore/useGetContentListByBoxType';
+import { FilterRadioButton } from '@components/explore/FilterRadioButton';
 
 export interface PosterCardScrollBoxProps {
   BoxTitle: string;
@@ -24,13 +25,37 @@ export const PosterCardScrollBox = ({
   const [selectedMovieId, setSelectedMovieId] = useState<number | null>(null);
 
   // 포스터 스크롤 박스 타입에 따라 콘텐츠 목록 조회 API 호출하는 custom Hook 호출
-  const { data: contentData } = useGetContentListByBoxType(BoxType);
+  const {
+    data: contentData,
+    isError,
+    refetch,
+  } = useGetContentListByBoxType(BoxType);
 
   const handlePosterClick = (movieId: number) => {
-    //TODO: 이것을 네트워크 통신으로 대체해야 함
     setSelectedMovieId(movieId);
     setIsDetailBottomSheetOpen(true);
   };
+
+  const handleRefetch = () => {
+    refetch();
+  };
+
+  // 에러 상태 또는 데이터가 없는 경우
+  if (isError || contentData.length === 0) {
+    return (
+      <div className="w-full h-fit flex flex-col justify-start items-start gap-2">
+        <span className="text-xl text-white font-semibold py-2 ml-6">
+          {BoxTitle}
+        </span>
+        <div className="w-full h-40 flex flex-col items-center justify-center gap-4 px-6">
+          <span className="text-white text-lg text-center">
+            불러올 정보가 없습니다
+          </span>
+          <FilterRadioButton onToggle={handleRefetch} label="다시 불러오기" />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="w-full h-fit flex flex-col justify-start items-start gap-2">

--- a/src/components/explore/PosterScrollBoxSkeleton.tsx
+++ b/src/components/explore/PosterScrollBoxSkeleton.tsx
@@ -1,0 +1,36 @@
+// src/components/explore/PosterScrollSkeleton.tsx
+import { Skeleton } from '@components/common/Skeleton';
+
+interface PosterScrollSkeletonProps {
+  title: string;
+  count?: number;
+}
+
+// 포스터 스크롤 박스 스켈레톤 컴포넌트
+export const PosterScrollSkeleton = ({
+  title,
+  count = 6,
+}: PosterScrollSkeletonProps) => {
+  return (
+    <div className="w-full h-fit flex flex-col justify-start items-start gap-2">
+      {/* 제목 */}
+      <span className="text-xl text-white font-semibold py-2 ml-6">
+        {title}
+      </span>
+
+      {/* 포스터 카드들 */}
+      <div className="w-full h-fit flex flex-row gap-3 overflow-x-auto scrollbar-hide px-6">
+        {Array.from({ length: count }).map((_, index) => (
+          <PosterCardSkeleton key={index} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// PosterCard와 동일한 크기의 Skeleton
+const PosterCardSkeleton = () => (
+  <div className="flex-shrink-0">
+    <Skeleton className="w-[110px] h-[154px] rounded-lg" />
+  </div>
+);

--- a/src/hooks/explore/useGetContentDetails.ts
+++ b/src/hooks/explore/useGetContentDetails.ts
@@ -1,12 +1,12 @@
 // lib/hooks/useContentDetails.ts
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getContentDetails } from '@lib/apis/explore/getContentDetails';
 import { DetailedContentData } from '@type/explore/Explore';
 
 // 특정 content ID에 대한 상세 정보 조회 API 호출하는 custom Hook
 // useSuspenseQuery를 사용하여 데이터가 없을 경우 자동으로 로딩 상태로 전환
 export const useGetContentDetails = (contentId: number) => {
-  return useSuspenseQuery<DetailedContentData>({
+  return useQuery<DetailedContentData>({
     queryKey: ['contentDetails', contentId],
     queryFn: () => getContentDetails(contentId),
     staleTime: 0, // 즉시 stale

--- a/src/hooks/explore/useGetContentListByBoxType.ts
+++ b/src/hooks/explore/useGetContentListByBoxType.ts
@@ -14,10 +14,12 @@ export const useGetContentListByBoxType = (
   const data = isPopular ? popularQuery.data : todayQuery.data; // 포스터 스크롤 박스 타입에 따라 콘텐츠 목록 반환
   const isLoading = isPopular ? popularQuery.isLoading : todayQuery.isLoading; // 포스터 스크롤 박스 타입에 따라 로딩 상태 반환
   const isError = isPopular ? popularQuery.isError : todayQuery.isError; // 포스터 스크롤 박스 타입에 따라 에러 상태 반환
+  const refetch = isPopular ? popularQuery.refetch : todayQuery.refetch; // 다시 불러오기 함수
 
   return {
     data: data || [],
     isLoading,
     isError,
+    refetch,
   };
 };

--- a/src/hooks/explore/useGetContentListByBoxType.ts
+++ b/src/hooks/explore/useGetContentListByBoxType.ts
@@ -12,14 +12,11 @@ export const useGetContentListByBoxType = (
   const todayQuery = useGetTodayRecommendContents(isToday); // 오늘의 추천 콘텐츠 데이터 조회일 때만 수행
 
   const data = isPopular ? popularQuery.data : todayQuery.data; // 포스터 스크롤 박스 타입에 따라 콘텐츠 목록 반환
-  const isLoading = isPopular ? popularQuery.isLoading : todayQuery.isLoading; // 포스터 스크롤 박스 타입에 따라 로딩 상태 반환
-  const isError = isPopular ? popularQuery.isError : todayQuery.isError; // 포스터 스크롤 박스 타입에 따라 에러 상태 반환
   const refetch = isPopular ? popularQuery.refetch : todayQuery.refetch; // 다시 불러오기 함수
 
   return {
     data: data || [],
-    isLoading,
-    isError,
+    status: isPopular ? popularQuery.status : todayQuery.status,
     refetch,
   };
 };

--- a/src/hooks/explore/useGetLatestContents.ts
+++ b/src/hooks/explore/useGetLatestContents.ts
@@ -1,14 +1,16 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
-import { SimpleContentData } from '@type/explore/Explore';
+import { useQuery } from '@tanstack/react-query';
+import { RecentContentData } from '@type/explore/Explore';
 import { getLatestContents } from '@lib/apis/explore/getLatestContents';
 
 // OTT 콘텐츠 인기 목록 조회 API 호출하는 custom Hook
 export const useGetLatestContents = () => {
-  return useSuspenseQuery<SimpleContentData[]>({
+  return useQuery<RecentContentData[]>({
     queryKey: ['latestContents'],
-    queryFn: getLatestContents,
+    queryFn: () => getLatestContents(10),
     staleTime: 0, // 바로 stale
     gcTime: 0, // 캐시 즉시 삭제
     refetchOnWindowFocus: false, // UX 보호용
+    retry: 2, // 자동 재시도(최대 2번까지)
+    retryDelay: 1000, // 재시도 딜레이(1초)
   });
 };

--- a/src/hooks/explore/useGetPopularContents.ts
+++ b/src/hooks/explore/useGetPopularContents.ts
@@ -6,7 +6,7 @@ import { getPopularContents } from '@lib/apis/explore/getPopularContents';
 export const useGetPopularContents = (enabled: boolean) => {
   return useQuery<SimpleContentData[]>({
     queryKey: ['popularContents'],
-    queryFn: getPopularContents,
+    queryFn: () => getPopularContents(10),
     staleTime: 0, // 바로 stale
     enabled: enabled, // 해당 쿼리 호출 여부 결정
     gcTime: 0, // 캐시 즉시 삭제

--- a/src/hooks/explore/useGetTodayRecommendContents.ts
+++ b/src/hooks/explore/useGetTodayRecommendContents.ts
@@ -6,7 +6,7 @@ import { getTodayContents } from '@lib/apis/explore/getTodayContents';
 export const useGetTodayRecommendContents = (enabled: boolean) => {
   return useQuery<SimpleContentData[]>({
     queryKey: ['todayRecommendContents'],
-    queryFn: getTodayContents,
+    queryFn: () => getTodayContents(10),
     staleTime: 0, // 바로 stale
     enabled: enabled, // 해당 쿼리 호출 여부 결정
     gcTime: 0, // 캐시 즉시 삭제

--- a/src/lib/apis/explore/getContentDetails.ts
+++ b/src/lib/apis/explore/getContentDetails.ts
@@ -7,5 +7,6 @@ export const getContentDetails = async (
 ): Promise<DetailedContentData> => {
   // axiosInstance를 사용하여 특정 contentId에 해당되는 상세 정보 조회 API 호출
   const res = await axiosInstance.get(`/api/contents/${contentId}`);
+  console.log('뭘 갖고 왔는데?: ', res);
   return res.data;
 };

--- a/src/lib/apis/explore/getLatestContents.ts
+++ b/src/lib/apis/explore/getLatestContents.ts
@@ -3,7 +3,13 @@ import axiosInstance from '@lib/apis/axiosInstance';
 import { RecentContentData } from '@type/explore/Explore';
 
 // 큰 카드들이 들어있는 Carousel 영역에 불러올 내용 (최대 10개까지 조회)
-export const getLatestContents = async (): Promise<RecentContentData[]> => {
-  const response = await axiosInstance.get('/api/contents/recent');
+export const getLatestContents = async (
+  size: number = 10,
+): Promise<RecentContentData[]> => {
+  const response = await axiosInstance.get('/api/contents/recent', {
+    params: {
+      size,
+    },
+  });
   return response.data;
 };

--- a/src/lib/apis/explore/getPopularContents.ts
+++ b/src/lib/apis/explore/getPopularContents.ts
@@ -2,9 +2,16 @@ import axiosInstance from '@lib/apis/axiosInstance';
 import { SimpleContentData } from '@type/explore/Explore';
 
 // OTT 콘텐츠 인기 목록 조회 API 호출 함수 (/api/contents/popular)
-export const getPopularContents = async (): Promise<SimpleContentData[]> => {
+export const getPopularContents = async (
+  size: number = 10,
+): Promise<SimpleContentData[]> => {
   const response = await axiosInstance.get<SimpleContentData[]>(
     '/api/contents/popular',
+    {
+      params: {
+        size,
+      },
+    },
   );
   return response.data;
 };

--- a/src/lib/apis/explore/getTodayContents.ts
+++ b/src/lib/apis/explore/getTodayContents.ts
@@ -1,10 +1,19 @@
 import { SimpleContentData } from '@type/explore/Explore';
 import axiosInstance from '../axiosInstance';
 
-// 오늘의 OTT 콘텐츠 추천 목록 조회 API 호출 함수 (/api/contents/today)
-export const getTodayContents = async (): Promise<SimpleContentData[]> => {
+// 오늘의 OTT 콘텐츠 추천 목록 조회 API 호출 함수 (/api/contents/weekly)
+export const getTodayContents = async (
+  size: number = 10,
+): Promise<SimpleContentData[]> => {
+  // Request Params 값으로 조회할 콘텐츠 개수 전달
   const res = await axiosInstance.get<SimpleContentData[]>(
     '/api/contents/weekly',
+    {
+      params: {
+        size,
+      },
+    },
   );
+
   return res.data;
 };

--- a/src/types/explore/Explore.ts
+++ b/src/types/explore/Explore.ts
@@ -36,7 +36,7 @@ export interface DetailedContentData {
 
   countries: string[]; // 예: ["미국", "영국"]
   directors: { name: string }[];
-  casts: { name: string; image: string }[];
+  casts: { castName: string; castImage: string }[];
 
   platforms: {
     platformType: string; // 예: "넷플릭스"

--- a/src/utils/checkImgSrcValidity.ts
+++ b/src/utils/checkImgSrcValidity.ts
@@ -1,0 +1,9 @@
+// 이미지 소스의 유효성을 검사하는 유틸리티 함수
+export function checkImgSrcValidity(rawSrc?: string): rawSrc is string {
+  return (
+    typeof rawSrc === 'string' &&
+    (rawSrc.startsWith('/') ||
+      rawSrc.startsWith('http://') ||
+      rawSrc.startsWith('https://'))
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
UDT-112

## 📝작업 내용
- TMI를 영어로 난사하는 codeRabbit의 설정 변경 (`.coderabbit.yaml` 파일 및 사이트에서도 특징 수정)
- API로부터 받아오는 이미지 source의 유효성을 검사하는 `checkImgSrcValidity` 메소드 추가
- “출연진”의 사진을 못 받아왔을 시에 출연진 이름의 맨 첫글자를 `<AvatarFallback>`에 띄우도록 변경
- `PosterCard` 및 `PosterCardScrollBox`에 로딩/오류 시 컴포넌트 처리 추가 (Skeleton UI, ‘다시 불러오기’ UI 추가)
- API의 안정적인 연동을 위해 `useGetPopularContents`, `useGetTodayRecommendContents` Custom Hook과, 그에 연관된 api 함수들 (`getPopularContents`, `getTodayContents`) 수정

**(➕ 7/23 추가사항)**
- `api/contents/recent` api와의 연동을 위해 `getLatestContents`, 그리고 이를 쉽게 사용하도록 해주는 `useGetLatestContents.ts` 수정
-  `useSuspenseQuery`를 사용 중이던 일부 custom Hook들에 대해, `useQuery`를 사용하는 것으로 변경 (해당 변경은 중소 규모의 우리 프로젝트에서 한 파일에서 모든 상태를 관리할 수 있는 `useQuery`가 더 적합하다는 것으로 판단하여 변경된 사안)
- 컴포넌트에서 데이터 로딩 및 에러 발생 시에 Fallback 처리를 위해 `useQuery`의 status 객체 값을 활용하도록 변경
- `PosterScrollBox`와 `ExplorePageCarousel`의 효율적인 Skeleton UI 처리를 위해 `components/common` 폴더에 공통 Skeleton 컴포넌트를 만들고, 이를 가져다 사용하는 방식으로 `PosterScrollBoxSkeleton`, `ExplorePageCarouselSkeleton` 컴포넌트 UI 제작

## 스크린샷
현재는 DB에 데이터가 존재하지 않아 `default-poster`, `default-backdrop` 이미지들이 뜨지만, api의 기본 동작들(무한스크롤 등)이 잘 동작하시는 것을 확인할 수 있습니다.

https://github.com/user-attachments/assets/2c8b983b-9123-4fa0-b168-1965d2572442

데이터가 로딩 되지 않을 시의 Fallback 처리와, 로딩 시 발생하는 Skeleton UI는 아래 영상에서 처럼 확인 가능합니다.

https://github.com/user-attachments/assets/e211faaa-b2a7-4113-ad41-32be46650e2a


## 💬리뷰 요구사항
- 무한스크롤, 받아온 콘텐츠 화면에 표시, Skeleton UI 등 모두 API와 연동했을 때, 잘 동작하는 것을 확인할 수 있었으나, 혹여나 제가 변경한 로직 중 불필요하거나, 효율적이지 못한 부분들이 있다면 리뷰 부탁드립니다!
- Api 연동을 위해 캐싱이 굳이 필요하지 않음에도 TanStack Query를 사용해서 `isLoading`, `isError` 등의 객체를 활용해 데이터 통신을 할 때 조금 더 분기 처리를 용이하게 만들었는데, 해당 부분이 비효율적이진 않은지 검토 부탁드립니다! 
- Skeleton UI의 확장성을 고려해서 공통적으로 사용하는 컴포넌트를 `components/common/Skeleton`에 저장하고, 이를 가져다 사용하는 방식으로 Skeleton을 구현 했는데, 해당 방식이 효율적일지 리뷰 부탁드립니다!


## ✅ 체크리스트
- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)