### PR TITLE
[UDT-107] API 연동 작업 및 전역 상태 관리 방식 변경

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,18 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'image.tmdb.org',
+        port: '',
+        pathname: '/t/p/**',
+      },
+    ],
+    // 또는 더 간단한 domains 방식 (deprecated되었지만 여전히 작동)
+    domains: ['image.tmdb.org'],
+  },
 };
 
 export default nextConfig;

--- a/src/app/recommend/RecommendContent.ts
+++ b/src/app/recommend/RecommendContent.ts
@@ -1,275 +1,335 @@
 import { TicketComponent } from '@/types/recommend/TicketComponent';
+import axiosInstance from '@/lib/apis/axiosInstance';
 
 // 실제로는 API에서 받아올 데이터
 let contentDataPool: TicketComponent[] = [
-  {
-    contentId: 1,
-    title: '주토피아',
-    description:
-      '토끼 경찰 주디 홉스와 여우 사기꾼 닉 와일드가 차별과 편견을 극복하며 공조 수사를 벌이는 이야기.',
-    posterUrl: '/images/mockPoster/zootopia-poster.webp',
-    backdropUrl: '/images/mockdata/zootopia.jpg',
-    openDate: '2019년 01월 17일',
-    runningTime: 104,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['판타지', '코미디'],
-    },
-    directors: ['바이런 하워드', '리치 무어'],
-    platforms: ['디즈니+'],
-  },
-  {
-    contentId: 2,
-    title: '타짜',
-    description:
-      '도박판의 세계에 발을 들인 고니의 복수극. 화투판 위에서 펼쳐지는 치열한 심리전.',
-    posterUrl: '/images/mockPoster/tazza-poster.webp',
-    backdropUrl: '/images/mockdata/tazza-backdrop.webp',
-    openDate: '2006년 09월 28일',
-    runningTime: 139,
-    episode: 1,
-    rating: '청소년 관람불가',
-    categories: {
-      category: '영화',
-      genres: ['범죄', '드라마'],
-    },
-    directors: ['최동훈'],
-    platforms: ['왓챠'],
-  },
-  {
-    contentId: 3,
-    title: '인사이드 아웃',
-    description:
-      '감정들이 주인공이 된 독특한 설정의 픽사 애니메이션. 아이의 성장과 정체성을 다룬 감동적인 여정.',
-    posterUrl: '/images/mockPoster/insideout-poster.webp',
-    backdropUrl: '/images/mockdata/insideout-backdrop.webp',
-    openDate: '2015년 06월 19일',
-    runningTime: 94,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['가족', '판타지'],
-    },
-    directors: ['피트 닥터'],
-    platforms: ['디즈니+'],
-  },
-  {
-    contentId: 4,
-    title: '이웃집 토토로',
-    description:
-      '자매와 숲의 정령 토토로의 만남. 순수함과 자연의 조화를 그린 힐링 애니메이션.',
-    posterUrl: '/images/mockPoster/totoro-poster.webp',
-    backdropUrl: '/images/mockdata/totoro-backdrop.webp',
-    openDate: '1988년 04월 16일',
-    runningTime: 86,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['판타지', '가족'],
-    },
-    directors: ['미야자키 하야오'],
-    platforms: ['넷플릭스'],
-  },
-  {
-    contentId: 5,
-    title: '센과 치히로의 행방불명',
-    description:
-      '이름을 빼앗긴 소녀 치히로가 신비한 세계에서 자아를 찾아가는 판타지 대서사시.',
-    posterUrl: '/images/mockPoster/sen-poster.webp',
-    backdropUrl: '/images/mockdata/sen-backdrop.webp',
-    openDate: '2001년 07월 20일',
-    runningTime: 125,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['판타지', '모험'],
-    },
-    directors: ['미야자키 하야오'],
-    platforms: ['넷플릭스'],
-  },
-  {
-    contentId: 6,
-    title: '하울의 움직이는 성',
-    description:
-      '노파가 된 소피가 하울과 함께 전쟁과 마법이 얽힌 세계를 여행하는 판타지 로맨스.',
-    posterUrl: '/images/mockPoster/haul-poster.webp',
-    backdropUrl: '/images/mockdata/haul-backdrop.jpeg',
-    openDate: '2004년 11월 20일',
-    runningTime: 119,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['로맨스', '전쟁'],
-    },
-    directors: ['미야자키 하야오'],
-    platforms: ['넷플릭스'],
-  },
-  {
-    contentId: 7,
-    title: '바람계곡의 나우시카',
-    description: '오염된 대지에서 평화를 추구하는 공주 나우시카의 생태 판타지.',
-    posterUrl: '/images/mockPoster/nausika-poster.webp',
-    backdropUrl: '/images/mockdata/nausika-backdrop.webp',
-    openDate: '1984년 03월 11일',
-    runningTime: 117,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['SF', '환경'],
-    },
-    directors: ['미야자키 하야오'],
-    platforms: ['넷플릭스'],
-  },
-  {
-    contentId: 8,
-    title: '마녀 배달부 키키',
-    description: '자립을 시작한 13살 마녀 키키의 성장과 배달 모험.',
-    posterUrl: '/images/mockPoster/kiki-poster.webp',
-    backdropUrl: '/images/mockdata/kiki-backdrop.webp',
-    openDate: '1989년 07월 29일',
-    runningTime: 103,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['성장', '힐링'],
-    },
-    directors: ['미야자키 하야오'],
-    platforms: ['넷플릭스'],
-  },
-  {
-    contentId: 9,
-    title: '모노노케 히메',
-    description:
-      '인간과 자연의 대립 속에서 진실을 찾아가는 청년 아시타카의 여정.',
-    posterUrl: '/images/mockPoster/hime-poster.webp',
-    backdropUrl: '/images/mockdata/hime-backdrop.jpg',
-    openDate: '1997년 07월 12일',
-    runningTime: 134,
-    episode: 1,
-    rating: '12세 이상',
-    categories: {
-      category: '애니메이션',
-      genres: ['판타지', '모험'],
-    },
-    directors: ['미야자키 하야오'],
-    platforms: ['넷플릭스'],
-  },
-  {
-    contentId: 10,
-    title: '라푼젤',
-    description:
-      '탑 속에 갇혀 지내던 라푼젤이 자유를 찾아 떠나는 모험과 자아 발견의 이야기.',
-    posterUrl: '/images/mockPoster/rapunzel-poster.webp',
-    backdropUrl: '/images/mockdata/rapunzel-backdrop.webp',
-    openDate: '2010년 11월 24일',
-    runningTime: 100,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['모험', '로맨스'],
-    },
-    directors: ['네이선 그레노', '바이런 하워드'],
-    platforms: ['디즈니+'],
-  },
-  {
-    contentId: 11,
-    title: '코코',
-    description:
-      '죽은 자들의 세상으로 간 소년 미겔이 가족과 음악의 소중함을 깨닫는 감동 스토리.',
-    posterUrl: '/images/mockPoster/coco-poster.webp',
-    backdropUrl: '/images/mockdata/coco-backdrop.webp',
-    openDate: '2017년 11월 24일',
-    runningTime: 105,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['음악', '가족'],
-    },
-    directors: ['리 언크리치'],
-    platforms: ['디즈니+'],
-  },
-  {
-    contentId: 12,
-    title: '벼랑 위의 포뇨',
-    description:
-      '물고기 소녀 포뇨와 소스케의 만남, 그리고 세상을 구하는 마법 같은 우정 이야기.',
-    posterUrl: '/images/mockPoster/ponyo-poster.webp',
-    backdropUrl: '/images/mockdata/ponyo-backdrop.webp',
-    openDate: '2008년 07월 19일',
-    runningTime: 101,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['판타지', '가족'],
-    },
-    directors: ['미야자키 하야오'],
-    platforms: ['넷플릭스'],
-  },
-  {
-    contentId: 13,
-    title: '업',
-    description:
-      '하늘을 나는 집과 함께 떠나는 노인 칼과 소년 러셀의 감동 모험 이야기.',
-    posterUrl: '/images/mockPoster/up-poster.webp',
-    backdropUrl: '/images/mockdata/up-backdrop.webp',
-    openDate: '2009년 05월 29일',
-    runningTime: 96,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['모험', '감동'],
-    },
-    directors: ['피트 닥터'],
-    platforms: ['디즈니+'],
-  },
-  {
-    contentId: 14,
-    title: '루카',
-    description:
-      '바닷속 괴물 소년 루카가 인간 세계에서 겪는 우정과 성장을 그린 여름 이야기.',
-    posterUrl: '/images/mockPoster/luca-poster.webp',
-    backdropUrl: '/images/mockdata/luca-backdrop.webp',
-    openDate: '2021년 06월 18일',
-    runningTime: 95,
-    episode: 1,
-    rating: '전체관람가',
-    categories: {
-      category: '애니메이션',
-      genres: ['성장', '우정'],
-    },
-    directors: ['엔리코 카사로사'],
-    platforms: ['디즈니+'],
-  },
+  // {
+  //   contentId: 1,
+  //   title: '주토피아',
+  //   description:
+  //     '토끼 경찰 주디 홉스와 여우 사기꾼 닉 와일드가 차별과 편견을 극복하며 공조 수사를 벌이는 이야기.',
+  //   posterUrl: '/images/mockPoster/zootopia-poster.webp',
+  //   backdropUrl: '/images/mockdata/zootopia.jpg',
+  //   openDate: '2019년 01월 17일',
+  //   runningTime: 104,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['판타지', '코미디'],
+  //   },
+  //   directors: ['바이런 하워드', '리치 무어'],
+  //   platforms: ['디즈니+'],
+  // },
+  // {
+  //   contentId: 2,
+  //   title: '타짜',
+  //   description:
+  //     '도박판의 세계에 발을 들인 고니의 복수극. 화투판 위에서 펼쳐지는 치열한 심리전.',
+  //   posterUrl: '/images/mockPoster/tazza-poster.webp',
+  //   backdropUrl: '/images/mockdata/tazza-backdrop.webp',
+  //   openDate: '2006년 09월 28일',
+  //   runningTime: 139,
+  //   episode: 1,
+  //   rating: '청소년 관람불가',
+  //   categories: {
+  //     category: '영화',
+  //     genres: ['범죄', '드라마'],
+  //   },
+  //   directors: ['최동훈'],
+  //   platforms: ['왓챠'],
+  // },
+  // {
+  //   contentId: 3,
+  //   title: '인사이드 아웃',
+  //   description:
+  //     '감정들이 주인공이 된 독특한 설정의 픽사 애니메이션. 아이의 성장과 정체성을 다룬 감동적인 여정.',
+  //   posterUrl: '/images/mockPoster/insideout-poster.webp',
+  //   backdropUrl: '/images/mockdata/insideout-backdrop.webp',
+  //   openDate: '2015년 06월 19일',
+  //   runningTime: 94,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['가족', '판타지'],
+  //   },
+  //   directors: ['피트 닥터'],
+  //   platforms: ['디즈니+'],
+  // },
+  // {
+  //   contentId: 4,
+  //   title: '이웃집 토토로',
+  //   description:
+  //     '자매와 숲의 정령 토토로의 만남. 순수함과 자연의 조화를 그린 힐링 애니메이션.',
+  //   posterUrl: '/images/mockPoster/totoro-poster.webp',
+  //   backdropUrl: '/images/mockdata/totoro-backdrop.webp',
+  //   openDate: '1988년 04월 16일',
+  //   runningTime: 86,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['판타지', '가족'],
+  //   },
+  //   directors: ['미야자키 하야오'],
+  //   platforms: ['넷플릭스'],
+  // },
+  // {
+  //   contentId: 5,
+  //   title: '센과 치히로의 행방불명',
+  //   description:
+  //     '이름을 빼앗긴 소녀 치히로가 신비한 세계에서 자아를 찾아가는 판타지 대서사시.',
+  //   posterUrl: '/images/mockPoster/sen-poster.webp',
+  //   backdropUrl: '/images/mockdata/sen-backdrop.webp',
+  //   openDate: '2001년 07월 20일',
+  //   runningTime: 125,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['판타지', '모험'],
+  //   },
+  //   directors: ['미야자키 하야오'],
+  //   platforms: ['넷플릭스'],
+  // },
+  // {
+  //   contentId: 6,
+  //   title: '하울의 움직이는 성',
+  //   description:
+  //     '노파가 된 소피가 하울과 함께 전쟁과 마법이 얽힌 세계를 여행하는 판타지 로맨스.',
+  //   posterUrl: '/images/mockPoster/haul-poster.webp',
+  //   backdropUrl: '/images/mockdata/haul-backdrop.jpeg',
+  //   openDate: '2004년 11월 20일',
+  //   runningTime: 119,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['로맨스', '전쟁'],
+  //   },
+  //   directors: ['미야자키 하야오'],
+  //   platforms: ['넷플릭스'],
+  // },
+  // {
+  //   contentId: 7,
+  //   title: '바람계곡의 나우시카',
+  //   description: '오염된 대지에서 평화를 추구하는 공주 나우시카의 생태 판타지.',
+  //   posterUrl: '/images/mockPoster/nausika-poster.webp',
+  //   backdropUrl: '/images/mockdata/nausika-backdrop.webp',
+  //   openDate: '1984년 03월 11일',
+  //   runningTime: 117,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['SF', '환경'],
+  //   },
+  //   directors: ['미야자키 하야오'],
+  //   platforms: ['넷플릭스'],
+  // },
+  // {
+  //   contentId: 8,
+  //   title: '마녀 배달부 키키',
+  //   description: '자립을 시작한 13살 마녀 키키의 성장과 배달 모험.',
+  //   posterUrl: '/images/mockPoster/kiki-poster.webp',
+  //   backdropUrl: '/images/mockdata/kiki-backdrop.webp',
+  //   openDate: '1989년 07월 29일',
+  //   runningTime: 103,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['성장', '힐링'],
+  //   },
+  //   directors: ['미야자키 하야오'],
+  //   platforms: ['넷플릭스'],
+  // },
+  // {
+  //   contentId: 9,
+  //   title: '모노노케 히메',
+  //   description:
+  //     '인간과 자연의 대립 속에서 진실을 찾아가는 청년 아시타카의 여정.',
+  //   posterUrl: '/images/mockPoster/hime-poster.webp',
+  //   backdropUrl: '/images/mockdata/hime-backdrop.jpg',
+  //   openDate: '1997년 07월 12일',
+  //   runningTime: 134,
+  //   episode: 1,
+  //   rating: '12세 이상',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['판타지', '모험'],
+  //   },
+  //   directors: ['미야자키 하야오'],
+  //   platforms: ['넷플릭스'],
+  // },
+  // {
+  //   contentId: 10,
+  //   title: '라푼젤',
+  //   description:
+  //     '탑 속에 갇혀 지내던 라푼젤이 자유를 찾아 떠나는 모험과 자아 발견의 이야기.',
+  //   posterUrl: '/images/mockPoster/rapunzel-poster.webp',
+  //   backdropUrl: '/images/mockdata/rapunzel-backdrop.webp',
+  //   openDate: '2010년 11월 24일',
+  //   runningTime: 100,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['모험', '로맨스'],
+  //   },
+  //   directors: ['네이선 그레노', '바이런 하워드'],
+  //   platforms: ['디즈니+'],
+  // },
+  // {
+  //   contentId: 11,
+  //   title: '코코',
+  //   description:
+  //     '죽은 자들의 세상으로 간 소년 미겔이 가족과 음악의 소중함을 깨닫는 감동 스토리.',
+  //   posterUrl: '/images/mockPoster/coco-poster.webp',
+  //   backdropUrl: '/images/mockdata/coco-backdrop.webp',
+  //   openDate: '2017년 11월 24일',
+  //   runningTime: 105,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['음악', '가족'],
+  //   },
+  //   directors: ['리 언크리치'],
+  //   platforms: ['디즈니+'],
+  // },
+  // {
+  //   contentId: 12,
+  //   title: '벼랑 위의 포뇨',
+  //   description:
+  //     '물고기 소녀 포뇨와 소스케의 만남, 그리고 세상을 구하는 마법 같은 우정 이야기.',
+  //   posterUrl: '/images/mockPoster/ponyo-poster.webp',
+  //   backdropUrl: '/images/mockdata/ponyo-backdrop.webp',
+  //   openDate: '2008년 07월 19일',
+  //   runningTime: 101,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['판타지', '가족'],
+  //   },
+  //   directors: ['미야자키 하야오'],
+  //   platforms: ['넷플릭스'],
+  // },
+  // {
+  //   contentId: 13,
+  //   title: '업',
+  //   description:
+  //     '하늘을 나는 집과 함께 떠나는 노인 칼과 소년 러셀의 감동 모험 이야기.',
+  //   posterUrl: '/images/mockPoster/up-poster.webp',
+  //   backdropUrl: '/images/mockdata/up-backdrop.webp',
+  //   openDate: '2009년 05월 29일',
+  //   runningTime: 96,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['모험', '감동'],
+  //   },
+  //   directors: ['피트 닥터'],
+  //   platforms: ['디즈니+'],
+  // },
+  // {
+  //   contentId: 14,
+  //   title: '루카',
+  //   description:
+  //     '바닷속 괴물 소년 루카가 인간 세계에서 겪는 우정과 성장을 그린 여름 이야기.',
+  //   posterUrl: '/images/mockPoster/luca-poster.webp',
+  //   backdropUrl: '/images/mockdata/luca-backdrop.webp',
+  //   openDate: '2021년 06월 18일',
+  //   runningTime: 95,
+  //   episode: 1,
+  //   rating: '전체관람가',
+  //   categories: {
+  //     category: '애니메이션',
+  //     genres: ['성장', '우정'],
+  //   },
+  //   directors: ['엔리코 카사로사'],
+  //   platforms: ['디즈니+'],
+  // },
 ];
 
-// 새로운 영화 데이터를 풀에 추가하는 함수
-export const addcontentDataPool = (newContent: TicketComponent[]): void => {
-  contentDataPool.push(...newContent);
+let isLoadingFromApi = false;
+
+// API에서 추천 콘텐츠를 가져오는 함수
+const fetchContents = async (
+  limit: number = 10,
+): Promise<TicketComponent[]> => {
+  try {
+    const response = await axiosInstance.get(
+      '/api/v1/contents/recommendations',
+      {
+        params: { limit },
+      },
+    );
+
+    // API 응답이 배열인지 확인
+    if (!Array.isArray(response.data)) {
+      console.error('API 응답이 배열 형태가 아닙니다:', response.data);
+      throw new Error('잘못된 API 응답 형식입니다.');
+    }
+
+    return response.data;
+  } catch (error) {
+    console.error('API에서 콘텐츠 가져오기 실패:', error);
+    throw error;
+  }
 };
 
-// 현재 사용 가능한 영화 데이터 가져오기
-export const getAvailableContents = (): TicketComponent[] => {
+// 새로운 영화 데이터를 풀에 추가하는 함수
+export const addContentDataPool = (newContent: TicketComponent[]): void => {
+  // 중복 제거: contentId 기준으로 중복 체크
+  const existingIds = new Set(
+    contentDataPool.map((content) => content.contentId),
+  );
+  const uniqueNewContent = newContent.filter(
+    (content) => !existingIds.has(content.contentId),
+  );
+
+  contentDataPool.push(...uniqueNewContent);
+};
+
+// Pool 초기화 함수 (필요시)
+export const clearContentDataPool = (): void => {
+  contentDataPool = [];
+};
+
+// 현재 사용 가능한 영화 데이터 가져오기 (pool이 비어있으면 API 호출)
+export const getAvailableContents = async (): Promise<TicketComponent[]> => {
+  // Pool이 비어있고 현재 로딩 중이 아닌 경우 API에서 데이터 가져오기
+  if (contentDataPool.length === 0 && !isLoadingFromApi) {
+    try {
+      isLoadingFromApi = true;
+      console.log('Pool이 비어있어서 API에서 데이터를 가져옵니다...');
+
+      const newContents = await fetchContents();
+      addContentDataPool(newContents);
+
+      console.log(`API에서 ${newContents.length}개의 콘텐츠를 가져왔습니다.`);
+    } catch (error) {
+      console.error('API 호출 실패:', error);
+      // API 실패 시 기본 목데이터라도 사용할 수 있도록 처리
+    } finally {
+      isLoadingFromApi = false;
+    }
+  }
+
   return [...contentDataPool]; // 복사본 반환
 };
 
 // 특정 범위의 영화 가져오기
-export const getContentsSlice = (
+export const getContentsSlice = async (
   start: number,
   count: number,
-): TicketComponent[] => {
-  return contentDataPool.slice(start, start + count);
+): Promise<TicketComponent[]> => {
+  const contents = await getAvailableContents();
+  return contents.slice(start, start + count);
 };
 
 // 풀 크기 확인
@@ -277,31 +337,37 @@ export const getPoolSize = (): number => {
   return contentDataPool.length;
 };
 
-// API 호출 시뮬레이션 (10초마다 실행될 함수)
-export const fetchMoreContents = async (): Promise<TicketComponent[]> => {
-  // 실제로는 axiosInstance.get('/recommend/more') 같은 API 호출
+// 추가 콘텐츠를 가져오는 함수 (API 연동)
+export const fetchMoreContents = async (
+  limit: number = 10,
+): Promise<TicketComponent[]> => {
+  try {
+    console.log(`추가 콘텐츠 ${limit}개를 API에서 가져옵니다...`);
 
-  const newMovies: TicketComponent[] = [
-    {
-      contentId: 10,
-      title: '플래시',
-      description:
-        '과거를 바꾸기 위해 시간여행을 한 플래시가 예상치 못한 결과로 인해 다중우주에서 벌어지는 모험.',
-      posterUrl: '/poster.webp',
-      backdropUrl: '/snapshot.webp',
-      openDate: '2023년 6월 14일',
-      runningTime: 144,
-      episode: 1,
-      rating: '12세이상관람가',
-      categories: {
-        category: '영화',
-        genres: ['애니메이션', '액션'],
-      },
-      directors: ['안드레스 무스키에티'],
-      platforms: ['넷플릭스', '디즈니+'],
-    },
-  ];
+    const newContents = await fetchContents(limit);
+    addContentDataPool(newContents);
 
-  addcontentDataPool(newMovies);
-  return newMovies;
+    console.log(
+      `${newContents.length}개의 추가 콘텐츠를 성공적으로 가져왔습니다.`,
+    );
+    return newContents;
+  } catch (error) {
+    console.error('추가 콘텐츠 가져오기 실패:', error);
+
+    // API 실패 시 빈 배열 반환
+    return [];
+  }
+};
+
+// Pool 상태 확인 함수
+export const getPoolStatus = (): {
+  size: number;
+  isEmpty: boolean;
+  isLoading: boolean;
+} => {
+  return {
+    size: contentDataPool.length,
+    isEmpty: contentDataPool.length === 0,
+    isLoading: isLoadingFromApi,
+  };
 };

--- a/src/app/recommend/ResultScreen.tsx
+++ b/src/app/recommend/ResultScreen.tsx
@@ -2,24 +2,32 @@
 
 import React, { useState, useEffect } from 'react';
 import { LoadingScreen } from './LoadingScreen';
-import { RefreshCw, Plus, Eye, EyeOff, Undo2 } from 'lucide-react';
+import { RefreshCw, Plus, Eye, EyeOff, Undo2, AlertCircle } from 'lucide-react';
 import { motion, AnimatePresence, type PanInfo } from 'framer-motion';
 import { Ticket } from '@components/Ticket/Ticket';
 import { Button } from '@components/ui/button';
-import { dummyMovies } from './ContentList';
 import { TicketComponent } from '@type/recommend/TicketComponent';
-import { getCuratedContents } from '@lib/apis/recommend/getCuratedContents';
 import { useRecommendStore } from '@store/useRecommendStore';
+import { useGetCuratedContents } from '@hooks/recommend/useGetCuratedContents';
+import { useQueryClient } from '@tanstack/react-query';
 
 export const ResultScreen: React.FC = () => {
-  const {
-    setPhase,
-    curatedContents,
-    setCuratedContents,
-    isResultLoading,
-    setIsResultLoading,
-  } = useRecommendStore();
+  const queryClient = useQueryClient();
 
+  // Zustand: UI 상태만
+  const { setPhase } = useRecommendStore();
+
+  // TanStack Query: API 상태만
+  const {
+    data: curatedContents = [],
+    isLoading,
+    isError,
+    error,
+    refetch,
+    isFetching,
+  } = useGetCuratedContents();
+
+  // 로컬 UI 상태들
   const [contents, setContents] = useState<TicketComponent[]>([]);
   const [rerollUsed, setRerollUsed] = useState<boolean[]>([
     false,
@@ -29,58 +37,40 @@ export const ResultScreen: React.FC = () => {
   const [currentIndex, setCurrentIndex] = useState(1);
   const [rerollCount, setRerollCount] = useState([0, 0, 0]);
   const [isFlipped, setIsFlipped] = useState<boolean[]>([false, false, false]);
+  const [showLoadingScreen, setShowLoadingScreen] = useState(() => {
+    const cachedData = queryClient.getQueryData(['curatedContents']);
+    return !cachedData;
+  });
 
+  // 큐레이션 데이터가 로드되면 contents 설정
   useEffect(() => {
-    const fetchCuratedContents = async (): Promise<void> => {
-      try {
-        setIsResultLoading(true);
+    if (curatedContents.length > 0) {
+      setContents(curatedContents.slice(0, 3));
 
-        // API 호출과 최소 3초 대기를 동시에 시작
-        const [response] = await Promise.all([
-          getCuratedContents(),
-          new Promise((resolve) => setTimeout(resolve, 3000)), // 3초 최소 대기
-        ]);
-
-        if (response.success && response.data.length > 0) {
-          setCuratedContents(response.data);
-          setContents(response.data.slice(0, 3));
-        } else {
-          // API 실패 시 fallback으로 더미 데이터
-          console.warn(
-            '큐레이션 데이터 로드 실패, 더미 데이터 사용:',
-            response.message,
-          );
-          setContents(dummyMovies.slice(0, 3));
-        }
-
-        setIsResultLoading(false);
-      } catch (error: unknown) {
-        console.error('큐레이션 콘텐츠 로드 중 오류:', error);
-        // 에러 시 fallback으로 더미 데이터
-        setContents(dummyMovies.slice(0, 3));
-        setIsResultLoading(false);
+      // 최소 3초 로딩 화면 표시 (UX 개선)
+      if (showLoadingScreen) {
+        const timer = setTimeout(() => {
+          setShowLoadingScreen(false);
+        }, 3000);
+        return () => clearTimeout(timer);
       }
-    };
-
-    fetchCuratedContents();
-  }, []);
+    }
+  }, [curatedContents, showLoadingScreen]);
 
   const handleReroll = (idx: number) => {
-    if (rerollUsed[idx] || curatedContents.length < 3 || dummyMovies.length < 6)
-      return;
+    if (rerollUsed[idx] || curatedContents.length < 6) return;
 
-    // 1단계: 카운터만 증가시켜서 exit 애니메이션 트리거
+    // 1단계: 카운터 증가로 exit 애니메이션 트리거
     setRerollCount((prev) => {
       const copy = [...prev];
       copy[idx] = copy[idx] + 1;
       return copy;
     });
 
-    // 2단계: exit 애니메이션 완료 후 새로운 데이터로 교체
+    // 2단계: 애니메이션 완료 후 새 데이터로 교체
     setTimeout(() => {
-      const next = [...curatedContents];
-      if (curatedContents.length >= 6) next[idx] = curatedContents[idx + 3];
-      else next[idx] = dummyMovies[idx + 3];
+      const next = [...contents];
+      next[idx] = curatedContents[idx + 3];
       setContents(next);
 
       setRerollUsed((prev) => {
@@ -88,7 +78,7 @@ export const ResultScreen: React.FC = () => {
         copy[idx] = true;
         return copy;
       });
-    }, 300); // exit 애니메이션 duration과 맞춤
+    }, 300);
   };
 
   const handleFlip = (idx: number) => {
@@ -101,7 +91,23 @@ export const ResultScreen: React.FC = () => {
 
   const handleAddContent = () => {
     const movie = contents[currentIndex];
-    if (movie) console.log('추가된 콘텐츠:', movie);
+    if (movie) {
+      console.log('추가된 콘텐츠:', movie);
+      // TODO: 선택된 콘텐츠를 사용자 관심 목록에 추가하는 API 호출
+    }
+  };
+
+  const handleStartNewRecommendation = () => {
+    // 큐레이션 캐시 무효화 (새로운 추천을 위해)
+    queryClient.invalidateQueries({ queryKey: ['curatedContents'] });
+
+    // 시작 화면으로 이동
+    setPhase('start');
+  };
+
+  const handleRetry = () => {
+    setShowLoadingScreen(true);
+    refetch();
   };
 
   const handleDragEnd = (_: unknown, info: PanInfo) => {
@@ -120,15 +126,86 @@ export const ResultScreen: React.FC = () => {
     };
   };
 
-  if (isResultLoading) return <LoadingScreen />;
+  // 로딩 중이거나 최소 3초 대기 중인 경우
+  if (isLoading || showLoadingScreen) {
+    return <LoadingScreen />;
+  }
+
+  // 에러 발생 시 에러 화면
+  if (isError) {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <div className="text-center max-w-md mx-auto px-4">
+          <AlertCircle className="w-16 h-16 text-red-500 mx-auto mb-4" />
+          <h2 className="text-2xl font-bold mb-4">
+            데이터를 불러올 수 없습니다
+          </h2>
+          <p className="text-gray-600 mb-6">
+            {error?.message || '알 수 없는 오류가 발생했습니다.'}
+          </p>
+          <div className="flex gap-4 justify-center">
+            <Button
+              onClick={handleRetry}
+              className="flex items-center gap-2"
+              disabled={isFetching}
+            >
+              <RefreshCw
+                className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`}
+              />
+              {isFetching ? '재시도 중...' : '다시 시도'}
+            </Button>
+            <Button variant="outline" onClick={() => setPhase('start')}>
+              처음으로
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 콘텐츠가 없는 경우
+  if (contents.length === 0) {
+    return (
+      <div className="flex min-h-full items-center justify-center">
+        <div className="text-center max-w-md mx-auto px-4">
+          <h2 className="text-2xl font-bold mb-4">추천할 콘텐츠가 없습니다</h2>
+          <p className="text-gray-600 mb-6">
+            다시 추천을 받아보시거나 잠시 후 시도해주세요.
+          </p>
+          <div className="flex gap-4 justify-center">
+            <Button
+              onClick={handleRetry}
+              className="flex items-center gap-2"
+              disabled={isFetching}
+            >
+              <RefreshCw
+                className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`}
+              />
+              {isFetching ? '새로고침 중...' : '새로고침'}
+            </Button>
+            <Button variant="outline" onClick={() => setPhase('start')}>
+              다시 추천받기
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-full items-center justify-center">
-      {/* overflow-hidden 제거 */}
       <div className="w-full">
         <div className="text-center mb-4">
           <h1 className="text-3xl font-bold mb-2">추천 결과</h1>
           <p className="text-gray-600">마음에 드는 콘텐츠를 선택해보세요</p>
+
+          {/* 데이터 소스 표시 (디버깅용, 나중에 제거 가능) */}
+          {/* {curatedContents.length > 0 && (
+            <p className="text-xs text-gray-400 mt-2">
+              {curatedContents.length >= 6 ? 'API' : 'Mock'} 데이터 (
+              {curatedContents.length}개)
+            </p>
+          )} */}
         </div>
 
         {/* Carousel Container */}
@@ -189,7 +266,6 @@ export const ResultScreen: React.FC = () => {
                     </AnimatePresence>
                   </div>
                 ) : (
-                  // 비중앙 카드는 static 렌더
                   <div className="relative w-full h-full">
                     <Ticket
                       movie={content}
@@ -222,11 +298,20 @@ export const ResultScreen: React.FC = () => {
                         variant="outline"
                         size="icon"
                         onClick={() => handleReroll(idx)}
-                        disabled={rerollUsed[idx]}
+                        disabled={rerollUsed[idx] || curatedContents.length < 6}
+                        title={
+                          curatedContents.length < 6
+                            ? '리롤할 추가 콘텐츠가 없습니다'
+                            : rerollUsed[idx]
+                              ? '이미 리롤을 사용했습니다'
+                              : '다른 콘텐츠로 바꾸기'
+                        }
                       >
                         <RefreshCw
                           className={`w-4 h-4 ${
-                            rerollUsed[idx] ? 'text-gray-60' : 'text-black'
+                            rerollUsed[idx] || curatedContents.length < 6
+                              ? 'text-gray-400'
+                              : 'text-black'
                           }`}
                         />
                       </Button>
@@ -238,7 +323,7 @@ export const ResultScreen: React.FC = () => {
           })}
         </div>
 
-        {/* Add Content Button */}
+        {/* Action Buttons */}
         <div className="flex justify-center mt-8 gap-4">
           <Button
             onClick={handleAddContent}
@@ -249,9 +334,7 @@ export const ResultScreen: React.FC = () => {
           </Button>
 
           <Button
-            onClick={() => {
-              setPhase('start');
-            }}
+            onClick={handleStartNewRecommendation}
             className="px-8 py-3 bg-primary-500 text-white rounded-full shadow-lg flex items-center gap-2"
           >
             <Undo2 className="w-5 h-5" />

--- a/src/components/Ticket/Ticket.tsx
+++ b/src/components/Ticket/Ticket.tsx
@@ -42,7 +42,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
           <div className="space-y-1 pb-2">
             <h3 className="font-bold text-lg leading-tight">{movie.title}</h3>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span>{movie.categories.genres.join(', ')}</span>
+              <span>{movie.genres.join(', ')}</span>
               <span>•</span>
               <span>{movie.rating}</span>
             </div>
@@ -153,7 +153,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
           <div className="space-y-1">
             <h3 className="font-bold text-lg leading-tight">{movie.title}</h3>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span>{movie.categories.genres.join(', ')}</span>
+              <span>{movie.genres.join(', ')}</span>
               <span>•</span>
               <span>{movie.rating}</span>
             </div>
@@ -216,7 +216,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
               {movie.title}
             </h3>
             <div className="flex flex-wrap gap-1 pb-5 justify-center">
-              {movie.categories.genres.slice(0, 4).map((genre) => (
+              {movie.genres.slice(0, 4).map((genre) => (
                 <Badge
                   key={genre}
                   variant="outline"
@@ -226,12 +226,12 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
                 </Badge>
               ))}
 
-              {movie.categories.genres.length > 4 && (
+              {movie.genres.length > 4 && (
                 <Badge
                   variant="outline"
                   className="text-xs border-white/30 text-white"
                 >
-                  +{movie.categories.genres.length - 4}
+                  +{movie.genres.length - 4}
                 </Badge>
               )}
             </div>

--- a/src/hooks/recommend/useGetCuratedContents.ts
+++ b/src/hooks/recommend/useGetCuratedContents.ts
@@ -1,0 +1,55 @@
+// src/hooks/recommend/useGetCuratedContents.ts
+import { useQuery } from '@tanstack/react-query';
+import { TicketComponent } from '@type/recommend/TicketComponent';
+import { getCuratedContents } from '@lib/apis/recommend/getCuratedContents';
+import { dummyMovies } from '@app/recommend/ContentList';
+
+export const useGetCuratedContents = () => {
+  return useQuery<TicketComponent[], Error>({
+    queryKey: ['curatedContents'],
+    queryFn: fetchCuratedContentsWithFallback,
+
+    staleTime: 1000 * 60 * 10,
+    gcTime: 1000 * 60 * 10, // 10분 후 자동 정리
+
+    refetchOnMount: false, // 컴포넌트 재마운트해도 refetch 안 함
+    refetchOnWindowFocus: false, // 탭 전환해도 refetch 안 함
+    refetchOnReconnect: false, // 네트워크 재연결해도 refetch 안 함
+    refetchInterval: false, // 주기적 refetch 안 함
+
+    retry: 2,
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+
+    throwOnError: false,
+  });
+};
+
+interface CuratedContentsResponse {
+  success: boolean;
+  data: TicketComponent[];
+  message?: string;
+}
+
+const fetchCuratedContentsWithFallback = async (): Promise<
+  TicketComponent[]
+> => {
+  try {
+    const response: CuratedContentsResponse = await getCuratedContents();
+
+    if (response.success && response.data && response.data.length > 0) {
+      console.log(`큐레이션 API 성공: ${response.data.length}개 콘텐츠 로드`);
+      return response.data;
+    }
+
+    // API 성공했지만 데이터가 없는 경우
+    console.warn(
+      '큐레이션 데이터가 없어서 더미 데이터 사용:',
+      response.message,
+    );
+    return dummyMovies;
+  } catch (error) {
+    console.error('큐레이션 API 오류:', error);
+    // API 실패 시 fallback으로 더미 데이터 반환
+    return dummyMovies;
+  }
+};

--- a/src/hooks/recommend/useGetRecommendationContents.ts
+++ b/src/hooks/recommend/useGetRecommendationContents.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import { getRecommendationContents } from '@/lib/apis/recommend/getRecommendationContents';
+import { TicketComponent } from '@/types/recommend/TicketComponent';
+
+export const useFetchRecommendations = () => {
+  return useMutation<TicketComponent[], Error, number>({
+    mutationFn: (limit: number) => getRecommendationContents(limit),
+
+    retry: 2,
+    retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 5000),
+
+    onSuccess: (data, limit) => {
+      console.log(`추천 콘텐츠 ${data.length}개 로드 성공 (limit: ${limit})`);
+    },
+
+    onError: (error, limit) => {
+      console.error(`추천 콘텐츠 로드 실패 (limit: ${limit}):`, error);
+    },
+
+    meta: {
+      description: '추천 콘텐츠 페칭 - 매번 새로운 결과',
+    },
+  });
+};

--- a/src/hooks/recommend/usePostFeedbacks.ts
+++ b/src/hooks/recommend/usePostFeedbacks.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 
-// MovieSwipePage 쪽과 동일한 타입
 export type FeedbackType = 'liked' | 'unliked' | 'neutral';
 
 interface FeedbackStore {

--- a/src/lib/apis/recommend/getCuratedContents.ts
+++ b/src/lib/apis/recommend/getCuratedContents.ts
@@ -15,7 +15,7 @@ export const getCuratedContents =
   async (): Promise<CuratedContentsResponse> => {
     try {
       const response = await axiosInstance.get<TicketComponent[]>(
-        '/api/recommend/curated',
+        '/api/v1/contents/recommendations/curated',
       );
 
       return {

--- a/src/lib/apis/recommend/getRecommendationContents.ts
+++ b/src/lib/apis/recommend/getRecommendationContents.ts
@@ -1,4 +1,3 @@
-// src/lib/apis/recommend/getRecommendationContents.ts
 import axiosInstance from '@lib/apis/axiosInstance';
 import { TicketComponent } from '@type/recommend/TicketComponent';
 import { AxiosResponse, AxiosError } from 'axios';
@@ -55,7 +54,7 @@ export const getRecommendationContents = async (
     console.log('추천 콘텐츠 API 요청 시작:', { limit });
 
     const response: AxiosResponse<TicketComponent[]> = await axiosInstance.get(
-      `/v1/contents/recommendations`,
+      `/api/v1/contents/recommendations`,
       {
         params: { limit },
       },

--- a/src/lib/apis/recommend/postFeedbackContent.ts
+++ b/src/lib/apis/recommend/postFeedbackContent.ts
@@ -28,7 +28,7 @@ export const postFeedbackContent = async (
     };
 
     const response = await axiosInstance.post(
-      '/recommend/contents/feedback',
+      '/api/recommend/contents/feedbacks',
       requestData,
     );
 

--- a/src/store/useRecommendStore.ts
+++ b/src/store/useRecommendStore.ts
@@ -1,4 +1,3 @@
-// src/store/useRecommendStore.ts
 import { create } from 'zustand';
 import { subscribeWithSelector, devtools } from 'zustand/middleware';
 import { TicketComponent } from '@/types/recommend/TicketComponent';
@@ -6,30 +5,21 @@ import { TicketComponent } from '@/types/recommend/TicketComponent';
 type Phase = 'start' | 'recommend' | 'result';
 
 interface RecommendState {
-  // 기존 phase 관리
   phase: Phase;
   setPhase: (phase: Phase) => void;
 
-  // 추천 진행 상황 관리
   moviePool: TicketComponent[];
   currentIndex: number;
   swipeCount: number;
+  totalSwipeCount: number;
 
-  // 엄선된 컨텐츠 관리
-  curatedContents: TicketComponent[];
-  isResultLoading: boolean;
-
-  // 액션들
   setMoviePool: (movies: TicketComponent[]) => void;
   addMoviesToPool: (newMovies: TicketComponent[]) => void;
   setCurrentIndex: (index: number) => void;
   incrementSwipeCount: () => void;
   resetSwipeCount: () => void;
   resetRecommendProgress: () => void;
-  setCuratedContents: (contents: TicketComponent[]) => void;
-  setIsResultLoading: (loading: boolean) => void;
 
-  // 헬퍼 함수들
   getCurrentMovie: () => TicketComponent | undefined;
   getNextMovie: () => TicketComponent | undefined;
   shouldLoadMoreContent: () => boolean;
@@ -39,50 +29,47 @@ interface RecommendState {
 export const useRecommendStore = create<RecommendState>()(
   devtools(
     subscribeWithSelector((set, get) => ({
-      // 기존 상태들
       phase: 'start',
-
-      // 새로운 상태들
       moviePool: [],
       currentIndex: 0,
       swipeCount: 0,
-      curatedContents: [],
-      isResultLoading: false,
+      totalSwipeCount: 0,
 
-      // 기존 액션
       setPhase: (phase: Phase) => set({ phase }),
 
-      // 새로운 액션들
       setMoviePool: (movies: TicketComponent[]) => set({ moviePool: movies }),
 
       addMoviesToPool: (newMovies: TicketComponent[]) =>
-        set((state) => ({
-          moviePool: [...state.moviePool, ...newMovies],
-        })),
+        set((state) => {
+          // const existingIds = new Set(state.moviePool.map((m) => m.contentId));
+          // const uniqueNewMovies = newMovies.filter(
+          //   (m) => !existingIds.has(m.contentId),
+          // );
+
+          // return {
+          //   moviePool: [...state.moviePool, ...uniqueNewMovies],
+          // };
+          return { moviePool: [...state.moviePool, ...newMovies] };
+        }),
 
       setCurrentIndex: (index: number) => set({ currentIndex: index }),
 
-      setIsResultLoading: (loading: boolean) =>
-        set({ isResultLoading: loading }),
-
       incrementSwipeCount: () =>
-        set((state) => ({ swipeCount: state.swipeCount + 1 })),
+        set((state) => ({
+          swipeCount: state.swipeCount + 1,
+          currentIndex: state.currentIndex + 1,
+          totalSwipeCount: state.totalSwipeCount + 1,
+        })),
 
-      resetSwipeCount: () => set(() => ({ swipeCount: 0 })),
+      resetSwipeCount: () => set({ swipeCount: 0 }),
 
       resetRecommendProgress: () =>
         set({
           moviePool: [],
           currentIndex: 0,
           swipeCount: 0,
-          curatedContents: [],
-          isResultLoading: false,
         }),
 
-      setCuratedContents: (contents: TicketComponent[]) =>
-        set({ curatedContents: contents }),
-
-      // 헬퍼 함수들
       getCurrentMovie: () => {
         const { moviePool, currentIndex } = get();
         return moviePool[currentIndex];
@@ -99,8 +86,8 @@ export const useRecommendStore = create<RecommendState>()(
       },
 
       shouldShowFinish: () => {
-        const { currentIndex } = get();
-        return currentIndex >= 5;
+        const { totalSwipeCount } = get();
+        return totalSwipeCount >= 20; // 5번 스와이프하면 결과 화면으로
       },
     })),
     { name: 'recommend-storage' },

--- a/src/types/recommend/TicketComponent.ts
+++ b/src/types/recommend/TicketComponent.ts
@@ -1,8 +1,3 @@
-export interface Category {
-  category: string;
-  genres: string[];
-}
-
 export interface TicketComponent {
   contentId: number;
   title: string;
@@ -11,9 +6,19 @@ export interface TicketComponent {
   backdropUrl: string;
   openDate: string;
   runningTime: number;
-  episode: number;
+  episode: string;
   rating: string;
-  categories: Category;
+  category: string;
+  genres: string[];
   directors: string[];
+  casts: string[];
   platforms: string[];
 }
+
+export const getMovieCategory = (movie: TicketComponent): string => {
+  return movie.category;
+};
+
+export const getMovieGenres = (movie: TicketComponent): string[] => {
+  return movie.genres;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈 (없으면 비워두세요) -> 어떤 이슈를 해결한 건지 연관되는 이슈 번호 작성

>UDT-107

## 📝작업 내용

 - Recommendation Contents, Curated Contents API에 맞춰 개별 hook(tanstack 기반) 으로 수정
 - FeedBack API 전송 되도록 수정
 - TicketComponent 타입 Response 변경에 맞게 살짝 수정
 - Curated Content 로딩에 맞게 Loading Screen 뜨도록 변경, refetch 없이 10분 후에 만료되게 변경
 - 총 SwipeCount가 아닌 Toast용 Count로 FinishScreen 트리거 되서 Finish 화면 뜨지 않던 현상 수정

## 💬리뷰 요구사항
- 확인하면서, 발생하는 Edge case나 오류 처리 과정에서 무슨 Screen 뜨는 지, 무슨 error throw하는 지 발견하면 알려주세요..
- 발견하거나, 혹은 생각 난다면 edge case 발생할 만한 시나리오가 뭔 지도 적어주세요.
- 현재는 Recommendation API 에서 항상 똑같은 값을(같은 limit에 대해서) 드랍하는데, 이건 백엔드 측에서 수정할 예정이라 이는 무시해도 괜찮습니다.
- Result 얻어내고 10분 지나면 만료되서 다시 Start Phase로 바뀝니다 참고

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
