### PR TITLE
[UDT-122] 마이페이지 엄선된 컨텐츠 삭제 api 연동 

### DIFF
--- a/src/app/profile/feedbacks/page.tsx
+++ b/src/app/profile/feedbacks/page.tsx
@@ -10,8 +10,8 @@ import { usePosterModal } from '@hooks/usePosterModal';
 import { useInfiniteFeedbacks } from '@hooks/profile/useInfiniteFeedbacks';
 import { useGetStoredContentDetail } from '@hooks/profile/useGetStoredContentDetail';
 import { FeedbackContent } from '@type/profile/FeedbackContent';
-import { useDeleteFeedbackToast } from '@hooks/profile/useDeleteFeedbackToast';
 import { useDeleteFeedback } from '@hooks/profile/useDeleteFeedback';
+import { useDeleteToast } from '@hooks/profile/useDeleteToast';
 
 const FeedbackPage = () => {
   const router = useRouter();
@@ -60,13 +60,13 @@ const FeedbackPage = () => {
       handleSelectAll,
       handleCancelDeleteMode,
     },
-  } = useDeleteMode(posters);
+  } = useDeleteMode(posters, (item) => item.feedbackId);
 
   // 실제 삭제 api 연동 토스토 확인 시 삭제 되도록 구성
   const { mutateAsync: deleteFeedback } = useDeleteFeedback();
 
   // 피드백 id의 경우 배열 처리로 수정하는데 시간이 걸린다 하여 우선 단일 처리 진행 후 수정
-  const { handleDelete } = useDeleteFeedbackToast({
+  const { handleDelete } = useDeleteToast({
     selectedIds,
     onDeleteComplete: handleCancelDeleteMode,
     deleteFn: deleteFeedback, // 단일 처리 함수
@@ -160,7 +160,7 @@ const FeedbackPage = () => {
       {/* 카드 리스트 */}
       <div className="w-full max-w-screen-md">
         {isEmpty ? (
-          <div className="text-center text-white/60 text-sm py-10">
+          <div className="flex flex-col items-center justify-center h-[calc(100vh-80px)] text-gray-400 text-sm font-medium">
             현재 저장된 콘텐츠가 없습니다.
           </div>
         ) : (

--- a/src/app/profile/recommend/page.tsx
+++ b/src/app/profile/recommend/page.tsx
@@ -10,7 +10,7 @@ import { PosterCard } from '@components/explore/PosterCard';
 import MovieDetailModal from '@components/profile/MovieDetailModal';
 import { useDeleteMode } from '@hooks/profile/useDeleteMode';
 import { useDeleteCurated } from '@hooks/profile/useDeleteCurated';
-import { useDeleteFeedbackToast } from '@hooks/profile/useDeleteFeedbackToast';
+import { useDeleteToast } from '@/hooks/profile/useDeleteToast';
 
 const RecommendPage = () => {
   const router = useRouter();
@@ -62,7 +62,7 @@ const RecommendPage = () => {
       handleSelectAll,
       handleCancelDeleteMode,
     },
-  } = useDeleteMode(posters);
+  } = useDeleteMode(posters, (item) => item.contentId);
 
   const handleCardClick = (poster: (typeof posters)[number]) => {
     if (isDeleteMode) {
@@ -75,7 +75,7 @@ const RecommendPage = () => {
   // 삭제 api 연동
   const { mutateAsync: deleteCurated } = useDeleteCurated();
 
-  const { handleDelete } = useDeleteFeedbackToast({
+  const { handleDelete } = useDeleteToast({
     selectedIds,
     onDeleteComplete: handleCancelDeleteMode,
     deleteFn: deleteCurated,
@@ -137,6 +137,8 @@ const RecommendPage = () => {
                 title={poster.title}
                 image={poster.posterUrl}
                 size="lg"
+                isDeletable={isDeleteMode}
+                isSelected={selectedIds.includes(poster.contentId)}
                 onClick={() => handleCardClick(poster)}
               />
             ))}

--- a/src/components/Ticket/Ticket.tsx
+++ b/src/components/Ticket/Ticket.tsx
@@ -22,6 +22,10 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
   const cardBaseClass =
     'flex flex-col min-w-[320px] min-h-[570px] md:min-w-[400px] md:min-h-[680px] max-w-[400px] max-h-[680px] border-none rounded-2xl overflow-hidden';
 
+  const [imgSrc, setImgSrc] = useState(
+    movie.backdropUrl || '/images/default-backdrop.png',
+  );
+
   useEffect(() => {
     const el = descRef.current;
     if (el) {
@@ -31,10 +35,6 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
   }, [movie.description]);
 
   if (variant === 'detail') {
-    const [imgSrc, setImgSrc] = useState(
-      movie.backdropUrl || '/images/default-backdrop.png',
-    );
-
     return (
       <Card className={cardBaseClass}>
         <div className="relative w-full min-h-[180px] md:min-h-[220px]">

--- a/src/components/Ticket/Ticket.tsx
+++ b/src/components/Ticket/Ticket.tsx
@@ -18,6 +18,10 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
   const [showMore, setShowMore] = useState(false);
   const descRef = useRef<HTMLParagraphElement>(null);
 
+  //카드 크기 고정을 위한 값지정
+  const cardBaseClass =
+    'flex flex-col min-w-[320px] min-h-[570px] md:min-w-[400px] md:min-h-[680px] max-w-[400px] max-h-[680px] border-none rounded-2xl overflow-hidden';
+
   useEffect(() => {
     const el = descRef.current;
     if (el) {
@@ -27,20 +31,25 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
   }, [movie.description]);
 
   if (variant === 'detail') {
+    const [imgSrc, setImgSrc] = useState(
+      movie.backdropUrl || '/images/default-backdrop.png',
+    );
+
     return (
-      <Card className="flex flex-col w-full h-full min-w-70 min-h-126 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
-        <div className="relative flex-grow">
+      <Card className={cardBaseClass}>
+        <div className="relative w-full min-h-[180px] md:min-h-[220px]">
           <Image
-            src={movie.posterUrl || '/placeholder.svg'}
+            src={imgSrc}
             alt={movie.title}
             fill
             className="object-cover"
             priority
+            onError={() => setImgSrc('/images/default-backdrop.png')}
           />
         </div>
         <CardHeader>
           <div className="space-y-1 pb-2">
-            <h3 className="font-bold text-lg leading-tight">{movie.title}</h3>
+            <h3 className="font-bold text-2xl leading-tight">{movie.title}</h3>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span>{movie.genres.join(', ')}</span>
               <span>•</span>
@@ -49,89 +58,93 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
           </div>
 
           <div className="space-y-2">
-            <h4 className="font-medium text-sm">플랫폼</h4>
+            <h4 className="font-medium text-sm md:text-lg">플랫폼</h4>
             <div className="flex flex-wrap gap-2">
-              {movie.platforms
-                .map((platform) => {
-                  const logo = getPlatformLogo(platform);
-                  return logo ? { platform, logo } : null;
-                })
-                .filter(
-                  (item): item is { platform: string; logo: string } => !!item,
-                )
-                .map(({ platform, logo }) => (
+              {movie.platforms.map((platformLabel) => {
+                const imageSrc = getPlatformLogo(platformLabel);
+                return imageSrc ? (
                   <CircleOption
-                    key={platform}
-                    label={platform}
-                    imageSrc={logo}
+                    key={platformLabel}
+                    label={platformLabel}
+                    imageSrc={imageSrc}
                     size="sm"
                     onClick={() => {}}
                     showLabel={false}
                   />
-                ))}
+                ) : null;
+              })}
             </div>
           </div>
         </CardHeader>
 
-        <CardContent
-          className={[
-            'flex flex-col space-y-3 py-2',
-            'flex-1',
-            expanded ? 'overflow-auto' : 'overflow-hidden',
-          ].join(' ')}
-        >
-          <div className="space-y-2 text-sm">
-            <div className="flex items-center gap-2">
-              <span className="text-gray-60">감독</span>
-              <span className="ml-auto">{movie.directors}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-gray-60">개봉일</span>
-              <span className="ml-auto">{movie.openDate}</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-gray-60">러닝타임</span>
-              <span className="ml-auto">{movie.runningTime}분</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-gray-60">연령 등급</span>
-              <span className="ml-auto">{movie.rating}</span>
-            </div>
-          </div>
+        <CardContent className="relative flex flex-col space-y-3 py-2 flex-1">
+          {!expanded ? (
+            <>
+              {/* 일반 정보 */}
+              <div className="space-y-2 text-sm md:text-base">
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-60">감독</span>
+                  <span className="ml-auto">{movie.directors}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-60">개봉일</span>
+                  <span className="ml-auto">{movie.openDate}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-60">러닝타임</span>
+                  <span className="ml-auto">{movie.runningTime}분</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-60">연령 등급</span>
+                  <span className="ml-auto">{movie.rating}</span>
+                </div>
+              </div>
 
-          <div className="flex flex-col flex-1">
-            <h4 className="font-medium text-sm mb-2">줄거리</h4>
-            <div
-              ref={descRef}
-              className={[
-                'text-sm text-muted-foreground leading-relaxed',
-                expanded
-                  ? 'overflow-auto' // flex-1 안에서 스크롤
-                  : 'line-clamp-3', // 3줄로 자름
-              ].join(' ')}
-            >
-              {movie.description}
-            </div>
-          </div>
+              {/* 줄거리 요약 */}
+              <div className="relative">
+                <h4 className="font-medium text-sm md:text-lg mb-2">줄거리</h4>
+                <p
+                  ref={descRef}
+                  className="text-sm md:text-base text-muted-foreground leading-relaxed line-clamp-2 md:line-clamp-3"
+                >
+                  {movie.description}
+                </p>
 
-          <div className="flex justify-end flex-shrink-0">
-            {!expanded && showMore && (
-              <button
-                onClick={() => setExpanded(true)}
-                className="text-xs text-gray-500 hover:underline"
-              >
-                더보기
-              </button>
-            )}
-            {expanded && (
-              <button
-                onClick={() => setExpanded(false)}
-                className="text-xs text-gray-500 hover:underline"
-              >
-                접기
-              </button>
-            )}
-          </div>
+                {showMore && (
+                  <div className="flex justify-end mt-1">
+                    <button
+                      onClick={() => setExpanded(true)}
+                      className="text-xs md:text-sm text-primary-500 hover:underline"
+                    >
+                      더보기 ▲
+                    </button>
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              {/* 줄거리 전체 - 기존 정보 사라지고 이거만 */}
+              <div className="flex flex-col justify-between flex-1">
+                <div>
+                  <h4 className="font-medium text-sm md:text-lg mb-2">
+                    줄거리
+                  </h4>
+                  <p className="text-sm md:text-base text-muted-foreground leading-relaxed whitespace-pre-wrap">
+                    {movie.description}
+                  </p>
+                </div>
+                <div className="flex justify-end mt-4">
+                  <button
+                    onClick={() => setExpanded(false)}
+                    className="text-xs md:text-sm text-primary-500 hover:underline"
+                  >
+                    접기 ▼
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
         </CardContent>
       </Card>
     );
@@ -139,10 +152,10 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'result') {
     return (
-      <Card className="flex flex-col w-full h-full min-w-70 min-h-126 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+      <Card className={cardBaseClass}>
         <div className="relative flex-grow">
           <Image
-            src={movie.posterUrl || '/placeholder.svg'}
+            src={movie.posterUrl || '/images/default-poster.png'}
             alt={movie.title}
             fill
             className="object-cover"
@@ -178,10 +191,10 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   if (variant === 'initial') {
     return (
-      <Card className="flex flex-col w-full h-full min-w-70 min-h-126 max-w-100 max-h-180 border-none rounded-2xl overflow-hidden">
+      <Card className={cardBaseClass}>
         <div className="relative flex-grow">
           <Image
-            src={movie.posterUrl || '/placeholder.svg'}
+            src={movie.posterUrl || '/images/default-poster.png'}
             alt={movie.title}
             fill
             className="object-cover"

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -57,7 +57,7 @@ export const showSimpleToast = {
       ),
       {
         duration: opts.duration ?? 4000,
-        position: opts.position ?? 'top-right',
+        position: opts.position ?? 'top-center',
       },
     );
   },
@@ -81,7 +81,7 @@ export const showSimpleToast = {
       ),
       {
         duration: opts.duration ?? 5000,
-        position: opts.position ?? 'top-right',
+        position: opts.position ?? 'top-center',
       },
     );
   },
@@ -105,7 +105,7 @@ export const showSimpleToast = {
       ),
       {
         duration: opts.duration ?? 4000,
-        position: opts.position ?? 'top-right',
+        position: opts.position ?? 'top-center',
       },
     );
   },
@@ -129,7 +129,7 @@ export const showSimpleToast = {
       ),
       {
         duration: opts.duration ?? 4000,
-        position: opts.position ?? 'top-right',
+        position: opts.position ?? 'top-center',
       },
     );
   },
@@ -152,7 +152,7 @@ export const showSimpleToast = {
       ),
       {
         duration: opts.duration ?? 4000,
-        position: opts.position ?? 'top-right',
+        position: opts.position ?? 'top-center',
       },
     );
   },

--- a/src/hooks/profile/useDeleteMode.ts
+++ b/src/hooks/profile/useDeleteMode.ts
@@ -1,49 +1,51 @@
 'use client';
 
 import { useState } from 'react';
-import { FeedbackContent } from '@/types/profile/FeedbackContent';
 
-export const useDeleteMode = (posters: FeedbackContent[]) => {
+export const useDeleteMode = <T>(
+  items: T[],
+  getId: (item: T) => number | undefined,
+) => {
   const [isDeleteMode, setIsDeleteMode] = useState(false);
-  const [selectedFeedbackIds, setSelectedFeedbackIds] = useState<number[]>([]);
+  const [selectedIds, setSelectedIds] = useState<number[]>([]);
   const [isAllSelected, setIsAllSelected] = useState(false);
 
-  const handleCardClickInDeleteMode = (poster: FeedbackContent) => {
-    const id = poster.feedbackId;
+  const handleCardClickInDeleteMode = (item: T) => {
+    const id = getId(item);
     if (id === undefined) return;
 
-    setSelectedFeedbackIds((prev) =>
+    setSelectedIds((prev) =>
       prev.includes(id) ? prev.filter((pid) => pid !== id) : [...prev, id],
     );
   };
 
   const handleSelectAll = () => {
-    const allIds = posters
-      .map((poster) => poster.feedbackId)
+    const allIds = items
+      .map(getId)
       .filter((id): id is number => id !== undefined);
 
-    setSelectedFeedbackIds(isAllSelected ? [] : allIds);
+    setSelectedIds(isAllSelected ? [] : allIds);
     setIsAllSelected(!isAllSelected);
   };
 
   const handleCancelDeleteMode = () => {
     setIsDeleteMode(false);
     setIsAllSelected(false);
-    setSelectedFeedbackIds([]);
+    setSelectedIds([]);
   };
 
   return {
     state: {
       isDeleteMode,
       isAllSelected,
-      selectedIds: selectedFeedbackIds,
+      selectedIds,
     },
     actions: {
       setIsDeleteMode,
       handleCardClickInDeleteMode,
       handleSelectAll,
       handleCancelDeleteMode,
-      setSelectedFeedbackIds,
+      setSelectedIds,
     },
   };
 };

--- a/src/hooks/profile/useDeleteToast.ts
+++ b/src/hooks/profile/useDeleteToast.ts
@@ -13,7 +13,7 @@ interface UseDeleteToastProps {
   isBatch?: boolean; //배열인지 안닌지 확인
 }
 
-export const useDeleteFeedbackToast = ({
+export const useDeleteToast = ({
   selectedIds,
   onDeleteComplete,
   deleteFn,
@@ -24,7 +24,8 @@ export const useDeleteFeedbackToast = ({
       showSimpleToast.error({
         message: '삭제할 콘텐츠를 선택해주세요.',
         position: 'top-center',
-        className: 'w-full bg-black/80 shadow-lg',
+        className:
+          'bg-black/80 text-white px-4 py-2 rounded-md mx-auto shadow-lg',
       });
       return;
     }
@@ -54,14 +55,16 @@ export const useDeleteFeedbackToast = ({
           showSimpleToast.success({
             message: '삭제가 완료되었습니다.',
             position: 'top-center',
-            className: 'w-full text-white bg-black',
+            className:
+              'bg-black text-white px-4 py-2 rounded-md mx-auto shadow-lg',
           });
           onDeleteComplete(); // 상태 초기화
         } catch {
           showSimpleToast.error({
             message: '삭제 중 오류가 발생했습니다.',
             position: 'top-center',
-            className: 'w-full text-white bg-black',
+            className:
+              'bg-black text-white px-4 py-2 rounded-md mx-auto shadow-lg',
           });
         }
       },

--- a/src/hooks/profile/usePreferenceHandler.ts
+++ b/src/hooks/profile/usePreferenceHandler.ts
@@ -24,7 +24,7 @@ export const usePreferenceHandler = (
     showSimpleToast.success({
       message,
       position: 'top-center',
-      className: 'w-full bg-black/80 shadow-lg text-white',
+      className: 'w-fit mx-auto bg-black text-white  shadow-lg',
     });
   };
 
@@ -33,7 +33,7 @@ export const usePreferenceHandler = (
     showSimpleToast.error({
       message,
       position: 'top-center',
-      className: 'w-full bg-black/80 shadow-lg text-white',
+      className: 'w-fit mx-auto bg-black text-white shadow-lg ',
     });
   };
 
@@ -62,11 +62,9 @@ export const usePreferenceHandler = (
       onConfirm: async () => {
         try {
           if (target === 'platform') {
-            console.log('[PATCH PLATFORM] 선택된 플랫폼:', selectedOtt);
             await patchPlatformsAsync(selectedOtt);
             showSuccess('OTT 설정이 저장되었습니다.');
           } else {
-            console.log('[PATCH GENRE] 선택된 장르:', selectedGenres);
             await patchGenresAsync(selectedGenres);
             showSuccess('선호 장르가 저장되었습니다.');
           }

--- a/src/lib/apis/profile/recommendService.ts
+++ b/src/lib/apis/profile/recommendService.ts
@@ -1,7 +1,7 @@
 import {
   GetRecommendedContentsResponse,
   RecommendedQueryParams,
-} from '@/types/profile/RecommendedContent';
+} from '@type/profile/RecommendedContent';
 import axiosInstance from '../axiosInstance';
 
 // [GET] /api/users/me/curated/contents 사용자의 엄선된 콘텐츠 목록 조회
@@ -17,12 +17,12 @@ export const getCuratedContents = async (
   return response.data;
 };
 
-//[DELETE] api/users/me/curated/contents 리스트 형태로 삭제
+//[DELETE] /api/api/users/me/curated/contents/bulk 리스트 형태로 삭제
 //현재 api 모름 임의로 작성
 export const deleteCuratedContents = async (
   contentIds: number[],
 ): Promise<void> => {
-  await axiosInstance.delete('/api/users/me/curated/contents/delete', {
+  await axiosInstance.delete('/api/api/users/me/curated/contents/bulk', {
     data: { contentIds },
   });
 };


### PR DESCRIPTION
## #️⃣연관된 이슈 (없으면 비워두세요) -> 어떤 이슈를 해결한 건지 연관되는 이슈 번호 작성

Udt 122

## 📝작업 내용

<ul>
  <li>엄선된 컨텐츠 삭제를 위한 api 작성</li>
  <li>엄선되 컨텐츠 , 피드백 컨텐츠의 삭제 방법 차이로(contentId , feedbackId) </li>
        삭제 모드(useDeleteMode)</strong>를 제네릭 타입으로 정의
    <ul>
      <li><code>feedbackId</code> 기반 삭제(피드백 콘텐츠)</li>
      <li><code>contentId</code> 기반 삭제(엄선된 콘텐츠)</li>
    </ul>
  <li>실제 삭제 처리의 경우 현재 api 엄선된 데이터는 배열 , 피드백 컨텐츠는 단일 삭제로 삭제 토스트 훅 분기처리<br />
    => 피드백은 시간이 좀....걸린다고 합니다. 추후 변경되는 데로 수정 예정
  </li>
      <li>티켓 반응형이 아닌 웹 / 모바일 두개로 분리  모바일 320*570 / 웹 400*680 / 글자 크기 수정</li>
      <li>더보기의 경우 감독 정보 사라지고 해당 정보 나오게끔 수정</li>
</ul>

### 스크린샷 

<img width="646" height="902" alt="스크린샷 2025-07-23 234620" src="https://github.com/user-attachments/assets/d711468e-f517-4922-8c66-9f7048d237e4" />

<img width="641" height="895" alt="스크린샷 2025-07-23 234650" src="https://github.com/user-attachments/assets/fd0379e2-e941-4eac-b34e-6b4b42a3f418" />

<img width="377" height="816" alt="스크린샷 2025-07-24 023936" src="https://github.com/user-attachments/assets/a5faf9b6-19cc-4cd4-bb1e-cd2c4ba2734d" />

<img width="648" height="898" alt="스크린샷 2025-07-24 023925" src="https://github.com/user-attachments/assets/7b7bfbc0-831f-4768-a13f-b77a4e7e2fba" />

https://github.com/user-attachments/assets/4aef1a62-71f7-4cd7-959e-48e1365c33e2

## 💬리뷰 요구사항(선택)

<img width="631" height="904" alt="스크린샷 2025-07-23 234657" src="https://github.com/user-attachments/assets/71c58822-c351-454c-add9-30409a7233ed" />

현재 showSimpleToast이 포지션을 센터로 줘도 스타일을 바꿔도 전역 처리를 해봐도? 자꾸 저렇게 치우쳐 나오는데
혹시 이유를 아시는 분 계실까용?

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
