### PR TITLE
[UDT-137] sonner 라이브러리를 통해 구현한 toast의 화면 정렬 문제 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,10 @@ export default function RootLayout({
     <html lang="ko">
       <body className="w-full flex justify-center bg-gray-100 min-h-screen overflow-x-hidden">
         <Providers>
-          <Toaster position="top-center" />
+          <Toaster
+            position="top-center"
+            toastOptions={{ className: 'w-full' }}
+          />
           <LayoutWrapper>{children}</LayoutWrapper>
         </Providers>
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID || ''} />

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -43,7 +43,7 @@ export const showSimpleToast = {
       () => (
         <div
           className={[
-            'flex items-center gap-2',
+            'flex items-center justify-center gap-2',
             'text-sm font-medium rounded-lg py-2 px-4',
             opts.className,
             'animate-enter',
@@ -67,7 +67,7 @@ export const showSimpleToast = {
       () => (
         <div
           className={[
-            'flex items-center gap-2',
+            'flex items-center justify-center gap-2',
             'text-sm font-medium rounded-lg py-2 px-4',
             opts.className,
             'animate-enter',
@@ -91,7 +91,7 @@ export const showSimpleToast = {
       () => (
         <div
           className={[
-            'flex items-center gap-2',
+            'flex items-center justify-center gap-2',
             'text-sm font-medium rounded-lg py-2 px-4',
             opts.className,
             'animate-enter',
@@ -115,7 +115,7 @@ export const showSimpleToast = {
       () => (
         <div
           className={[
-            'flex items-center gap-2',
+            'flex items-center justify-center gap-2',
             'text-sm font-medium rounded-lg py-2 px-4',
             opts.className,
             'animate-enter',
@@ -139,7 +139,7 @@ export const showSimpleToast = {
       () => (
         <div
           className={[
-            'text-sm font-medium rounded-lg py-2 px-4',
+            'text-sm font-medium justify-center rounded-lg py-2 px-4',
             'bg-gray-600 text-white',
             opts.className,
             'animate-enter',
@@ -215,7 +215,7 @@ export const showInteractiveToast = {
           className={[
             'flex flex-col justify-between',
             'rounded-lg p-4',
-            'w-[340px] mx-auto',
+            'mx-auto',
             'shadow-sm',
             opts.className,
             'animate-enter',

--- a/src/hooks/profile/useDeleteToast.ts
+++ b/src/hooks/profile/useDeleteToast.ts
@@ -35,7 +35,7 @@ export const useDeleteToast = ({
       confirmText: '삭제',
       cancelText: '취소',
       position: 'top-center',
-      className: 'w-[360px] bg-white shadow-lg',
+      className: 'bg-white shadow-lg',
       onConfirm: async () => {
         try {
           if (isBatch) {
@@ -56,7 +56,7 @@ export const useDeleteToast = ({
             message: '삭제가 완료되었습니다.',
             position: 'top-center',
             className:
-              'bg-black text-white px-4 py-2 rounded-md mx-auto shadow-lg',
+              'bg-primary-300/80 text-white px-4 py-2 rounded-md mx-auto shadow-lg',
           });
           onDeleteComplete(); // 상태 초기화
         } catch {


### PR DESCRIPTION
## #️⃣연관된 이슈
UDT-137

## 📝작업 내용
- `sonner` 라이브러리를 활용한 Toast 컴포넌트가 화면에 pop-up 될 때, `top-center`(가운데 정렬)되지 않는 문제 수정
- `useDeleteToast` custom Hook에서 "삭제가 완료되었습니다" Toast 관련하여 배경색 및 글자 정렬 변경

## 스크린샷
Toast 가운데 정렬을 시키기 위한 고난과 역경의 과정..............🥹 집념은 승리한다

https://github.com/user-attachments/assets/5b0a7ba8-575c-4471-a042-dd7ebb851816


## 💬리뷰 요구사항
- 핵심적으로 최상단 `layout.tsx` 파일에서 `Toaster` 컴포넌트에 `toastOptions` props 값을 넘기니 해결 되었습니다. 이런 방법으로 문제를 해결하긴 했는데, 해당 방법이 다른 CSS 속성에 영향을 줄 수 있는지 검토 부탁드립니다!

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
