### PR TITLE
[UDT-131] axiosInstance 인증 오류 시 로그인창 리다이렉트 및 useQueryErrorToast Hook 추가

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -14,6 +14,7 @@ import {
 import { PosterCardScrollBox } from '@/components/explore/PosterCardScrollBox';
 import { useFetchTodayRecommendSentence } from '@/hooks/explore/useFetchTodayRecommendSentence';
 import { usePageStayTracker } from '@hooks/usePageStayTracker';
+import { useQueryErrorToast } from '@/hooks/useQueryErrorToast';
 
 export default function ExplorePage() {
   // 페이지 머무르는 시간 추적 (탐색 페이지 추적 / Google Analytics 연동을 위함)
@@ -29,12 +30,18 @@ export default function ExplorePage() {
   const filters = appliedFilters.length > 0 ? appliedFilters : undefined;
 
   // 필터링된 콘텐츠 목록 조회 (필터 옵션을 이용해서 request param 생성해서 데이터를 받아온다, filter 비어 있으면 수행 X)
+  const getFilteredContentsQuery = useGetFilteredContents({
+    size: 12,
+    filters: createFilterRequestParam(filters ?? []),
+    enabled: filters !== undefined,
+  });
+
+  // 쿼리에서 에러가 발생했을 경우, 토스트 띄우기
+  useQueryErrorToast(getFilteredContentsQuery);
+
+  // getFilteredContentsQuery 객체에서 필요한 것 추출
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
-    useGetFilteredContents({
-      size: 12,
-      filters: createFilterRequestParam(filters ?? []),
-      enabled: filters !== undefined,
-    });
+    getFilteredContentsQuery;
 
   // 필터링된 콘텐츠 목록 데이터 추출
   const contents = data?.pages.flatMap((page) => page.item) || [];

--- a/src/app/profile/edit/page.tsx
+++ b/src/app/profile/edit/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ChevronLeft } from 'lucide-react';
 import { CircleOption } from '@components/common/circleOption';
@@ -18,6 +18,7 @@ import { usePreferenceHandler } from '@hooks/profile/usePreferenceHandler';
 import { useGetUserProfile } from '@hooks/useGetUserProfile';
 import { showSimpleToast } from '@components/common/Toast';
 import { usePageStayTracker } from '@/hooks/usePageStayTracker';
+import { useQueryErrorToast } from '@/hooks/useQueryErrorToast';
 
 export default function EditPreferencePage() {
   // 페이지 머무르는 시간 추적 (프로필 수정 페이지 추적 / Google Analytics 연동을 위함)
@@ -27,7 +28,13 @@ export default function EditPreferencePage() {
   const [selectedGenres, setSelectedGenres] = useState<string[]>([]);
   const router = useRouter();
   const { handleSave } = usePreferenceHandler(selectedOtt, selectedGenres);
-  const { data: userProfile } = useGetUserProfile();
+  const userQuery = useGetUserProfile(); // 유저 프로필 조회 쿼리 전체 가져오기 (에러 핸들링에서 용이함을 위함)
+
+  // 쿼리에서 에러가 발생했을 경우, 토스트 띄우기
+  useQueryErrorToast(userQuery);
+
+  // userQuery.data가 변경될 때만 새로운 값을 반환하도록 함
+  const userProfile = useMemo(() => userQuery.data, [userQuery.data]);
 
   useEffect(() => {
     if (userProfile) {

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -17,6 +17,8 @@ import { useGetUserProfile } from '@hooks/useGetUserProfile';
 import { Skeleton } from '@components/ui/skeleton';
 import { useLogoutHandler } from '@hooks/profile/useLogoutHandler';
 import { usePageStayTracker } from '@hooks/usePageStayTracker';
+import { useQueryErrorToast } from '@/hooks/useQueryErrorToast';
+import { useMemo } from 'react';
 
 const ProfilePage = () => {
   // 페이지 머무르는 시간 추적 (프로필 페이지 추적 / Google Analytics 연동을 위함)
@@ -24,7 +26,13 @@ const ProfilePage = () => {
 
   const router = useRouter();
 
-  const { data: userProfile, isLoading, isError } = useGetUserProfile();
+  const userQuery = useGetUserProfile(); // 유저 프로필 조회 쿼리 전체 가져오기 (에러 핸들링에서 용이함을 위함)
+
+  // 쿼리에서 에러가 발생했을 경우, 토스트 띄우기
+  useQueryErrorToast(userQuery);
+
+  // userQuery.data가 변경될 때만 새로운 값을 반환하도록 함
+  const userProfile = useMemo(() => userQuery.data, [userQuery.data]);
 
   const handleEditClick = () => {
     router.push('/profile/edit');
@@ -32,7 +40,7 @@ const ProfilePage = () => {
 
   const { handleLogout } = useLogoutHandler();
 
-  if (isLoading) {
+  if (userQuery.status === 'pending') {
     return (
       <div className="h-[calc(100vh-80px)] overflow-y-auto w-full mx-auto px-4 pt-6 text-white flex flex-col items-center">
         <div className="w-full flex justify-center mb-16 h-10">
@@ -67,7 +75,7 @@ const ProfilePage = () => {
     );
   }
 
-  if (isError || !userProfile) {
+  if (userQuery.status === 'error' || !userProfile) {
     return (
       <p className="text-red-500 text-center mt-10">
         유저 정보를 불러오지 못했습니다.

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from 'sonner';
 import { Button } from '@components/ui/button';
+
 import {
   X,
   Check,

--- a/src/components/explore/PosterCardScrollBox.tsx
+++ b/src/components/explore/PosterCardScrollBox.tsx
@@ -83,9 +83,9 @@ export const PosterCardScrollBox = ({
         {BoxTitle}
       </span>
       <div className="w-full h-fit flex flex-row gap-3 overflow-x-auto scrollbar-hide px-6">
-        {contentData.map((movie) => (
+        {contentData.map((movie, idx) => (
           <PosterCard
-            key={movie.contentId}
+            key={`${movie.contentId}-${idx}`}
             title={'타이틀없음'}
             image={movie.posterUrl}
             isTitleVisible={false}

--- a/src/hooks/useGetUserProfile.ts
+++ b/src/hooks/useGetUserProfile.ts
@@ -1,9 +1,10 @@
 import { UserProfile } from '@type/auth/UserProfile';
 import { useQuery } from '@tanstack/react-query';
 import { authService } from '@lib/apis/authService';
+import { AxiosError } from 'axios';
 
 export const useGetUserProfile = () => {
-  return useQuery<UserProfile, Error>({
+  return useQuery<UserProfile, AxiosError>({
     queryKey: ['userProfile'],
     queryFn: authService.getCurrentUser,
     staleTime: 1000 * 60 * 5, // 5분간 fresh

--- a/src/hooks/useQueryErrorToast.ts
+++ b/src/hooks/useQueryErrorToast.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import { QueryObserverResult } from '@tanstack/react-query';
+import { showSimpleToast } from '@components/common/Toast';
+import { AxiosError } from 'axios';
+
+// 타입가드 함수 사용
+function isAxiosError(error: unknown): error is AxiosError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'isAxiosError' in error &&
+    (error as AxiosError).isAxiosError === true
+  );
+}
+
+// 단일 쿼리에 대해 에러 토스트를 띄울지의 여부를 결정하는 useQueryErrorToast 훅 (tanstack query의 에러 핸들링에서 용이함을 위함)
+export function useQueryErrorToast<TData = unknown, TError = AxiosError>(
+  query: QueryObserverResult<TData, TError>,
+  customMsg?: string,
+) {
+  const toastShown = useRef(false); // 토스트 띄운 상태 추적 (중복 발생 방지)
+
+  useEffect(() => {
+    if (query.isError && query.error && !toastShown.current) {
+      toastShown.current = true;
+
+      // 안전하게 AxiosError만 status, response 접근
+      let statusCode: number | undefined = undefined;
+      let errorMsg: string = '';
+
+      if (isAxiosError(query.error)) {
+        statusCode = query.error.response?.status;
+      }
+
+      // 각 상황에 따라서 분기 처리 (커스텀 메시지 우선 사용, 없으면 status 값에 따라 메시지 설정)
+      if (customMsg) {
+        errorMsg = customMsg;
+      } else {
+        switch (statusCode) {
+          case 400:
+            errorMsg = '잘못된 요청입니다. Error Code: 400';
+            break;
+          case 401:
+            errorMsg =
+              '로그인이 만료되었습니다. 다시 로그인 해주세요. Error Code: 401';
+            break;
+          case 403:
+            errorMsg = '권한이 없습니다. Error Code: 403';
+            break;
+          case 404:
+            errorMsg = '존재하지 않는 리소스입니다. Error Code: 404';
+            break;
+          case 409:
+            errorMsg = '중복된 요청입니다. Error Code: 409';
+            break;
+          case 500:
+            errorMsg = '서버 오류가 발생했습니다. Error Code: 500';
+            break;
+          default:
+            // 서버에서 내려주는 message 우선 사용, 없으면 기본 메시지
+            errorMsg = '예상치 못한 오류가 발생했습니다.';
+        }
+      }
+
+      showSimpleToast.error({
+        message: errorMsg,
+        position: 'top-center',
+        className:
+          'bg-red-500/70 text-white px-4 py-2 rounded-md mx-auto shadow-lg',
+        duration: 2500,
+      });
+
+      toastShown.current = false; // 토스트 띄운 상태 초기화
+    }
+  }, [query.isError, query.error, customMsg]);
+}

--- a/src/lib/apis/axiosInstance.ts
+++ b/src/lib/apis/axiosInstance.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosResponse, AxiosError } from 'axios';
+import { showSimpleToast } from '@components/common/Toast';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || '/api';
 
@@ -11,6 +12,7 @@ const axiosInstance: AxiosInstance = axios.create({
   },
 });
 
+// 토큰 재발급 로직
 const reissueToken = async (): Promise<boolean> => {
   try {
     const response = await axios.post(
@@ -25,13 +27,21 @@ const reissueToken = async (): Promise<boolean> => {
   }
 };
 
+// 로그아웃 처리 함수
+const handleLogout = () => {
+  // 필요한 경우 store 클리어, 캐시 클리어 등
+  if (typeof window !== 'undefined') {
+    window.location.href = '/';
+  }
+};
+
 // 응답 인터셉터 설정
 axiosInstance.interceptors.response.use(
   (response: AxiosResponse) => response,
   async (error: AxiosError) => {
     const originalRequest = error.config;
 
-    // 401 에러 && 재시도하지 않은 요청
+    // 401: 인증 만료, 재발급 시도 (다른 오류들 400, 500 등은 tanstack query에서의 onError에서 처리해야 함)
     if (
       error.response?.status === 401 &&
       originalRequest &&
@@ -47,26 +57,31 @@ axiosInstance.interceptors.response.use(
           return axiosInstance(originalRequest);
         } else {
           // 토큰 재발급 실패 시 로그아웃 처리
+          showSimpleToast.error({
+            message:
+              '로그인이 만료되었습니다. 다시 로그인 해주세요. Error Code: 401',
+            position: 'top-center',
+            className:
+              'bg-red-500/70 text-white px-4 py-2 rounded-md mx-auto shadow-lg',
+            duration: 2500,
+          });
           handleLogout();
           return Promise.reject(error);
         }
       } catch (reissueError) {
+        showSimpleToast.error({
+          message: '인증 과정 중 문제가 발생했습니다. 로그아웃을 진행합니다.',
+          duration: 2500,
+        });
         console.log(reissueError);
         handleLogout();
         return Promise.reject(error);
       }
     }
+
     return Promise.reject(error);
   },
 );
-
-// 로그아웃 처리 함수
-const handleLogout = () => {
-  // 필요한 경우 store 클리어, 캐시 클리어 등
-  if (typeof window !== 'undefined') {
-    window.location.href = '/login';
-  }
-};
 
 export default axiosInstance;
 


### PR DESCRIPTION
## #️⃣연관된 이슈
UDT-131

## 📝작업 내용
- `axiosInstance`에서 서비스 이용 중 401 오류(토큰 만료 등의 인증 문제) 발생 시, 기존의 `showSimpleToast`를 이용하여 에러 토스트를 띄우고 로그인 창으로 redirect 시키는 기능 추가
- Tanstack Query를 사용하여 네트워크 통신을 통해 response를 받아오는 다양한 hook에서 에러 핸들링 처리를 위한 `useQueryErrorToast` 훅 추가

## 🍽️새로 추가된 `useQueryErrorToast` 훅 사용법
- 해당 Hook은 Tanstack Query를 사용하여 get, post 요청 등을 진행하는 모든 query 객체(`useInfiniteQuery`, `useQuery` 등의 모든 쿼리 객체 사용 가능)를 매개 변수로 넘기게 되면, 에러 발생 시 `AxiosError` 객체의 오류 status code를 감지하여 그에 알맞는 Toast 메시지를 띄워주는 역할을 합니다.
- Query/Mutation에서 error 타입을 반드시 AxiosError로 지정해 주세요!
  ```typescript
  const userQuery = useQuery<User, AxiosError>(...);
  const updateMutation = useMutation<..., AxiosError>(...);
  ```

컴포넌트 내에서 다음처럼 훅을 사용하세요:

  ```typescript
  import { useQueryErrorToast } from '@/hooks/useQueryErrorToast';
  
  // 예시 - 쿼리 에러 처리
  const userQuery = useGetUserProfile();
  useQueryErrorToast(userQuery);
  
  // 예시 - 뮤테이션 에러 처리
  const updateMutation = usePatchGenre();
  useQueryErrorToast(updateMutation, '장르 변경에 실패했습니다.');
  ```

- 해당 Query/Mutation이 “모든 retry 끝에 최종 실패” 시에만, toast가 한 번 뜹니다.
- HTTP status 코드별로 메시지가 자동 분기됩니다.
- 직접 메시지를 주고 싶으면 두 번째 인자(customMsg)로 전달하세요. (필수 매개변수는 아닙니다)

## 스크린샷
나이스......

https://github.com/user-attachments/assets/7f915307-7b64-4709-8900-5099c28ac461

## 💬리뷰 요구사항
- 직접 구현한 `useQueryErrorToast`가 비효율적인지, 아니면 혹여나 오류가 있는지 검토해 주시면 감사하겠읍니다🥹


## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
