### PR TITLE
[UDT-130] Ticket 컴포넌트 반응형 디자인 수정, 모바일/개발자 도구 애니메이션 수정, 스와이프 및 로딩 수정

### DIFF
--- a/src/app/recommend/LoadingScreen.tsx
+++ b/src/app/recommend/LoadingScreen.tsx
@@ -1,33 +1,28 @@
 // components/LoadingScreen.tsx
 'use client';
 
+import SparkleBackground from '@/components/common/sparkle_background';
 import React from 'react';
 
-export const LoadingScreen: React.FC = () => (
+interface LoadingScreenProps {
+  message: string;
+  submessage: string;
+}
+
+export const LoadingScreen: React.FC<LoadingScreenProps> = ({
+  message,
+  submessage,
+}) => (
   <div className="min-h-screen flex items-center justify-center relative overflow-hidden">
-    <div className="absolute inset-0">
-      {[...Array(30)].map((_, i) => (
-        <div
-          key={i}
-          className="absolute w-1 h-1 bg-white rounded-full opacity-0 animate-star-appear"
-          style={{
-            left: `${Math.random() * 100}%`,
-            top: `${Math.random() * 100}%`,
-            animationDelay: `${i * 0.1}s`,
-          }}
-        />
-      ))}
-    </div>
+    <SparkleBackground />
     <div className="text-center text-white z-10">
       <div className="mb-8 animate-fade-in-up" style={{ animationDelay: '1s' }}>
-        <h2 className="text-xl font-medium mb-2 animate-typing">
-          추천 결과를 갖고 오고 있어요...
-        </h2>
+        <h2 className="text-xl font-medium mb-2 animate-typing">{message}</h2>
         <p
           className="text-sm opacity-80 animate-fade-in"
           style={{ animationDelay: '1.5s' }}
         >
-          잠시만 기다려주세요....
+          {submessage}
         </p>
       </div>
       <div className="mb-8 flex justify-center">
@@ -52,26 +47,6 @@ export const LoadingScreen: React.FC = () => (
             <div className="absolute top-1 right-1 w-16 h-16 rounded-full bg-gradient-to-br from-slate-900 to-purple-900"></div>
           </div>
         </div>
-      </div>
-      <div
-        className="opacity-0 animate-fade-in-up"
-        style={{ animationDelay: '4.5s' }}
-      >
-        <div className="inline-block px-8 py-3 bg-white/20 backdrop-blur-sm rounded-full border border-white/30 animate-glow">
-          <span className="text-sm font-medium">반달별 시작하기</span>
-        </div>
-      </div>
-      <div
-        className="flex justify-center mt-6 space-x-1 opacity-0 animate-fade-in"
-        style={{ animationDelay: '5s' }}
-      >
-        {[...Array(3)].map((_, i) => (
-          <div
-            key={i}
-            className="w-2 h-2 bg-white/60 rounded-full animate-bounce"
-            style={{ animationDelay: `${i * 0.2}s` }}
-          />
-        ))}
       </div>
     </div>
   </div>

--- a/src/app/recommend/RecommendScreen.tsx
+++ b/src/app/recommend/RecommendScreen.tsx
@@ -281,6 +281,31 @@ export function RecommendScreen({ onComplete }: Readonly<RecommendProps>) {
     }
   };
 
+  const onTouchStart = (e: React.TouchEvent): void => {
+    if (isAnimating || e.touches.length !== 1) return;
+    e.preventDefault();
+    const touch = e.touches[0];
+    setStartPoint({ x: touch.clientX, y: touch.clientY });
+  };
+
+  const onTouchEnd = (e: React.TouchEvent): void => {
+    if (!startPoint || e.changedTouches.length !== 1) return;
+    e.preventDefault();
+    const touch = e.changedTouches[0];
+    const dx: number = touch.clientX - startPoint.x;
+    const dy: number = touch.clientY - startPoint.y;
+    setStartPoint(null);
+    const absX: number = Math.abs(dx);
+    const absY: number = Math.abs(dy);
+    const threshold: number = 100; // 모바일에 맞게 임계값 낮춤
+
+    if (absX > absY && absX > threshold) {
+      handleSwipe(dx > 0 ? 'right' : 'left', dx > 0 ? 'liked' : 'unliked');
+    } else if (dy < -threshold) {
+      handleSwipe('up');
+    }
+  };
+
   // ── transform 클래스 계산 ──────────────────────
   const getCardTransform = (): string => {
     if (!swipeDirection) return '';
@@ -354,9 +379,18 @@ export function RecommendScreen({ onComplete }: Readonly<RecommendProps>) {
           className={`relative inline-block mx-10 w-full select-none ${
             isFlipped ? 'touch-action-auto' : 'touch-action-none'
           }`}
+          style={{
+            touchAction: isFlipped ? 'auto' : 'none',
+            WebkitTouchCallout: 'none',
+            WebkitUserSelect: 'none',
+            userSelect: 'none',
+          }}
           onPointerDown={onPointerDown}
           onPointerUp={onPointerUp}
           onPointerCancel={() => setStartPoint(null)}
+          onTouchStart={onTouchStart}
+          onTouchEnd={onTouchEnd}
+          onTouchCancel={() => setStartPoint(null)}
         >
           {/* 자리 채우기 티켓 */}
           <div className="relative flex w-full aspect-[75/135] max-w-100 max-h-180 invisible pointer-events-none items-center justify-center">

--- a/src/app/recommend/RecommendScreen.tsx
+++ b/src/app/recommend/RecommendScreen.tsx
@@ -9,6 +9,7 @@ import { useRecommendStore } from '@store/useRecommendStore';
 import { useFetchRecommendations } from '@hooks/recommend/useGetRecommendationContents';
 import { FinishScreen } from './FinishScreen';
 import { sendAnalyticsEvent } from '@lib/gtag';
+import { LoadingScreen } from './LoadingScreen';
 
 type SwipeDirection = 'left' | 'right' | 'up';
 type FeedbackType = 'liked' | 'unliked' | 'neutral';
@@ -53,6 +54,16 @@ export function RecommendScreen({ onComplete }: Readonly<RecommendProps>) {
   const [startPoint, setStartPoint] = useState<{ x: number; y: number } | null>(
     null,
   );
+  const [loadingDelayOver, setLoadingDelayOver] = useState(false);
+
+  // ── 로딩 지연 상태 관리 ──────────────────────────
+  useEffect(() => {
+    // 기존 데이터가 있으면 로딩 지연 건너뛰기
+    if (moviePool.length > 0) {
+      console.log('기존 데이터 존재, 로딩 지연 건너뛰기');
+      setLoadingDelayOver(true);
+    }
+  }, [moviePool.length]);
 
   // ── 초기 데이터 로드 ────────────────────────────
   useEffect(() => {
@@ -63,23 +74,33 @@ export function RecommendScreen({ onComplete }: Readonly<RecommendProps>) {
           currentIndex,
           swipeCount,
         });
+        setLoadingDelayOver(true); // 기존 데이터 있으면 즉시 완료
         return;
       }
 
       try {
         console.log('초기 콘텐츠 로딩 시작...');
-        const initialMovies = await fetchRecommendations(10);
+
+        // API 호출과 최소 2초 지연을 동시에 실행
+        const [initialMovies] = await Promise.all([
+          fetchRecommendations(10),
+          new Promise((resolve) => setTimeout(resolve, 2000)), // 최소 2초 대기
+        ]);
+
         console.log(
           `${initialMovies.length}개의 초기 콘텐츠가 로드되었습니다.`,
         );
         setMoviePool(initialMovies);
+        setLoadingDelayOver(true); // API 완료 + 2초 지연 후 완료
       } catch (error) {
         console.error('초기 콘텐츠 로딩 실패:', error);
+        // 에러 시에도 2초 후 완료
+        setTimeout(() => setLoadingDelayOver(true), 2000);
       }
     };
 
     loadInitialMovies();
-  }, []); // 빈 의존성 배열 - 한 번만 실행
+  }, []);
 
   // 현재 영화 정보
   const currentMovie = getCurrentMovie();
@@ -168,19 +189,19 @@ export function RecommendScreen({ onComplete }: Readonly<RecommendProps>) {
     if (feedbackType) setFeedback(feedbackType);
     setIsFlipped(false);
 
-    // 즉시 피드백 전송
+    // 즉시 피드백 전송 (현재 콘텐츠에 대해)
     if (feedbackType && currentMovie) {
       sendFeedbackImmediately(currentMovie.contentId, feedbackType);
     }
 
-    // Store 업데이트
-    incrementSwipeCount();
-
-    // 애니메이션 → 인덱스 이동
+    // 애니메이션 완료 후 콘텐츠 변경
     setTimeout(() => {
       setSwipeDirection(null);
-      setCurrentIndex(currentIndex + 1);
       setFeedback('neutral');
+
+      // 상태 업데이트를 애니메이션 완료 후로 이동
+      incrementSwipeCount();
+      setCurrentIndex(currentIndex + 1);
     }, 700);
 
     // 애니메이션 잠금 해제
@@ -288,11 +309,12 @@ export function RecommendScreen({ onComplete }: Readonly<RecommendProps>) {
   }
 
   // ── 로딩 상태 ─────────────────────────────────
-  if (isLoading && moviePool.length === 0) {
+  if (!loadingDelayOver || (isLoading && moviePool.length === 0)) {
     return (
-      <div className="flex flex-1 flex-col items-center justify-center">
-        <div className="text-white text-lg">콘텐츠를 로딩 중...</div>
-      </div>
+      <LoadingScreen
+        message="컨텐츠 목록을 불러오고 있어요!"
+        submessage="잠시만 기다려주세요...."
+      />
     );
   }
 
@@ -422,12 +444,6 @@ export function RecommendScreen({ onComplete }: Readonly<RecommendProps>) {
         >
           {isFlipped ? '돌아가기' : '상세보기'}
         </Button>
-
-        {/* 진행률 표시 */}
-        <div className="text-white/70 text-sm">
-          진행률: {swipeCount}/5
-          {isLoading && <span className="ml-2">(추가 로딩 중...)</span>}
-        </div>
       </div>
     </div>
   );

--- a/src/app/recommend/StartScreen.tsx
+++ b/src/app/recommend/StartScreen.tsx
@@ -5,6 +5,7 @@ import { Play, Film } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { Button } from '@components/ui/button';
 import { useRecommendStore } from '@store/useRecommendStore';
+import SparkleBackground from '@/components/common/sparkle_background';
 
 interface StartScreenProps {
   onStart: () => void;
@@ -40,29 +41,7 @@ export const StartScreen: React.FC<StartScreenProps> = ({ onStart }) => {
   return (
     <div className="flex flex-col min-h-screen items-center justify-center relative overflow-hidden">
       {/* Animated background stars */}
-      <div className="absolute inset-0">
-        {[...Array(50)].map((_, i) => (
-          <motion.div
-            key={i}
-            className="absolute w-1 h-1 bg-white rounded-full"
-            initial={{ opacity: 0, scale: 0 }}
-            animate={{
-              opacity: [0, 1, 0.8, 1],
-              scale: [0, 1.2, 1, 1.2],
-            }}
-            transition={{
-              duration: 3,
-              delay: i * 0.05,
-              repeat: Number.POSITIVE_INFINITY,
-              repeatType: 'reverse',
-            }}
-            style={{
-              left: `${Math.random() * 100}%`,
-              top: `${Math.random() * 100}%`,
-            }}
-          />
-        ))}
-      </div>
+      <SparkleBackground />
 
       {/* Floating movie icons */}
       {/* <div className="absolute inset-0 pointer-events-none">
@@ -156,7 +135,7 @@ export const StartScreen: React.FC<StartScreenProps> = ({ onStart }) => {
               추천을 시작해볼까요?
             </h2>
             <p className="text-purple-100 text-lg leading-relaxed">
-              컨텐츠들에 대해서 사용자님의 생각을 알려주시면
+              주어진 컨텐츠들에 대한 생각을 알려주시면
               <br />
               가장 적합한 컨텐츠를 추천해드려요!
             </p>

--- a/src/components/Ticket/Ticket.tsx
+++ b/src/components/Ticket/Ticket.tsx
@@ -20,10 +20,14 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
 
   //카드 크기 고정을 위한 값지정
   const cardBaseClass =
-    'flex flex-col min-w-[320px] min-h-[570px] md:min-w-[400px] md:min-h-[680px] max-w-[400px] max-h-[680px] border-none rounded-2xl overflow-hidden';
+    'flex flex-col min-w-[280px] min-h-[480px] max-w-[400px] max-h-[680px] w-full h-full border-none rounded-2xl overflow-hidden';
 
-  const [imgSrc, setImgSrc] = useState(
+  const [backdropSrc, setBackdropSrc] = useState(
     movie.backdropUrl || '/images/default-backdrop.png',
+  );
+
+  const [posterSrc, setPosterSrc] = useState(
+    movie.posterUrl || '/images/default-poster.png',
   );
 
   useEffect(() => {
@@ -39,21 +43,19 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
       <Card className={cardBaseClass}>
         <div className="relative w-full min-h-[180px] md:min-h-[220px]">
           <Image
-            src={imgSrc}
+            src={backdropSrc}
             alt={movie.title}
             fill
             className="object-cover"
             priority
-            onError={() => setImgSrc('/images/default-backdrop.png')}
+            onError={() => setBackdropSrc('/images/default-backdrop.png')}
           />
         </div>
         <CardHeader>
           <div className="space-y-1 pb-2">
             <h3 className="font-bold text-2xl leading-tight">{movie.title}</h3>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span>{movie.genres.join(', ')}</span>
-              <span>•</span>
-              <span>{movie.rating}</span>
+              <div>{movie.genres.join(', ')}</div>
             </div>
           </div>
 
@@ -77,7 +79,7 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
           </div>
         </CardHeader>
 
-        <CardContent className="relative flex flex-col space-y-3 py-2 flex-1">
+        <CardContent className="relative flex flex-col space-y-3 py-3 flex-1">
           {!expanded ? (
             <>
               {/* 일반 정보 */}
@@ -155,11 +157,12 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
       <Card className={cardBaseClass}>
         <div className="relative flex-grow">
           <Image
-            src={movie.posterUrl || '/images/default-poster.png'}
+            src={posterSrc}
             alt={movie.title}
             fill
             className="object-cover"
             priority
+            onError={() => setPosterSrc('/images/default-poster.png')}
           />
         </div>
         <CardHeader>
@@ -167,13 +170,13 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
             <h3 className="font-bold text-lg leading-tight">{movie.title}</h3>
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <span>{movie.genres.join(', ')}</span>
-              <span>•</span>
-              <span>{movie.rating}</span>
+              {/* <span>•</span>
+              <span>{movie.rating}</span> */}
             </div>
           </div>
         </CardHeader>
 
-        <CardContent className="flex flex-col space-y-3">
+        <CardContent className="flex flex-col py-3 space-y-3">
           <div className="space-y-2 text-sm">
             <div className="flex items-center gap-2">
               <span className="text-gray-60">감독</span>
@@ -194,11 +197,12 @@ export const Ticket = ({ movie, variant, feedback }: TicketProps) => {
       <Card className={cardBaseClass}>
         <div className="relative flex-grow">
           <Image
-            src={movie.posterUrl || '/images/default-poster.png'}
+            src={posterSrc}
             alt={movie.title}
             fill
             className="object-cover"
             priority
+            onError={() => setPosterSrc('/images/default-poster.png')}
           />
           {feedback === 'liked' && (
             <div className="absolute inset-0 z-20 flex justify-start items-center bg-like/70">

--- a/src/components/common/sparkle_background.tsx
+++ b/src/components/common/sparkle_background.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+
+interface Star {
+  id: number;
+  left: number;
+  top: number;
+  delay: number;
+}
+
+const SparkleBackground: React.FC = () => {
+  const [stars, setStars] = useState<Star[]>([]);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // 컴포넌트가 마운트된 후에만 별들을 생성
+    setMounted(true);
+
+    const generateStars = (): Star[] => {
+      return Array.from({ length: 30 }, (_, i) => ({
+        id: i,
+        left: Math.random() * 100,
+        top: Math.random() * 100,
+        delay: i * 0.1,
+      }));
+    };
+
+    setStars(generateStars());
+  }, []);
+
+  // 마운트되기 전에는 아무것도 렌더링하지 않음
+  if (!mounted) {
+    return <div className="absolute inset-0" />;
+  }
+
+  return (
+    <div className="absolute inset-0">
+      {stars.map((star) => (
+        <div
+          key={star.id}
+          className="absolute w-1 h-1 bg-white rounded-full opacity-0 animate-star-appear"
+          style={{
+            left: `${star.left}%`,
+            top: `${star.top}%`,
+            animationDelay: `${star.delay}s`,
+          }}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default SparkleBackground;

--- a/src/hooks/recommend/usePostCuratedContents.ts
+++ b/src/hooks/recommend/usePostCuratedContents.ts
@@ -17,7 +17,15 @@ export const usePostCuratedContent = (
   const { showToast = true } = options || {};
 
   return useMutation({
-    mutationFn: (contentId: number) => postCuratedContent(contentId),
+    mutationFn: async (contentId: number) => {
+      const result = await postCuratedContent(contentId);
+      if (!result.success) {
+        throw new Error(result.message || '저장에 실패했습니다.');
+      }
+
+      return result;
+    },
+
     retry: 3,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
 
@@ -39,10 +47,14 @@ export const usePostCuratedContent = (
       console.error('컨텐츠 저장 실패:', error.message);
 
       options?.onOptimisticRevert?.(contentId);
+      const isAlreadyExists = error.message.includes('이미 저장된');
+      const errorMessage = isAlreadyExists
+        ? '이미 저장된 콘텐츠입니다.'
+        : '저장에 실패하였습니다.';
       // Toast 표시
       if (showToast) {
         showSimpleToast.error({
-          message: `저장에 실패하였습니다.`,
+          message: errorMessage,
           duration: 4000,
           position: 'top-center',
           className: 'bg-destructive text-white',


### PR DESCRIPTION
## #️⃣연관된 이슈

> UDT-130

## 📝작업 내용

- Ticket 컴포넌트가 Result, Recommend Screen에서 모두 반응형으로 사이즈 조정 가능하도록 변경
- ResultScreen에서 Ticket 간의 간격 화면 사이즈, Ticket 사이즈에 맞게 바뀌게 수정
- RecommendScreen 앞에도 LoadingScreen 추가, LoadingScreen에 props를 넘겨 재사용할 수 있도록 변경
- Ticket 이미지 로드 실패 시 poster, backdrop각각 placeholder로 대체 가능하도록 변경

- 모바일/ 개발자 도구를 위한 Touch 애니메이션 관련 메서드 및 스타일 추가
- 스와이프 시 currentIndex가 바로 변경되어 스와이프 애니메이션 도중 다음 컨텐츠의 정보가 표기되는 현상 수정
- 엄선된 컨텐츠 저장 시 409 Conflict response 받을 떄 저장 거부 인터액션 구현 완

### 스크린샷 

<img width="437" height="934" alt="image" src="https://github.com/user-attachments/assets/3d9ebd27-4058-44d5-a614-7f0fb4b41751" />
<img width="428" height="933" alt="image" src="https://github.com/user-attachments/assets/5b4c8b1f-87ba-4753-9b2f-a4d1bdf7f365" />


## 💬리뷰 요구사항

> 여기 명시되지 않은 버그 발견 시 바로바로 알려주세요!

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
