### PR TITLE
hotfix: 설문조사(survey) 페이지 데이터 타입 및 종료 시점 일시 변경

### DIFF
--- a/src/app/survey/page.tsx
+++ b/src/app/survey/page.tsx
@@ -2,7 +2,7 @@
 
 import Step1 from '@components/survey/Step1';
 import Step2 from '@components/survey/Step2';
-import Step3 from '@components/survey/Step3';
+// import Step3 from '@components/survey/Step3';
 import SurveyComplete from '@components/survey/SurveyComplete';
 import { useState } from 'react';
 import { SurveyProvider } from '@store/SurveyContext';
@@ -17,8 +17,8 @@ function SurveyFlow() {
     useSurveyContext();
 
   const handleNext = async () => {
-    if (step < 3) {
-      setStep((prev) => (prev + 1) as 1 | 2 | 3 | 4);
+    if (step < 2) {
+      setStep((prev) => (prev + 1) as 1 | 2 | 3);
     } else {
       try {
         await postSurvey({
@@ -26,7 +26,7 @@ function SurveyFlow() {
           genres: selectedGenres,
           contentIds: watchedContents,
         });
-        setStep(4); // 성공 시 완료 페이지로 이동
+        setStep(3); // 성공 시 완료 페이지로 이동
       } catch {
         showSimpleToast.error({
           message: '설문조사 제출에 실패했습니다.',
@@ -39,8 +39,8 @@ function SurveyFlow() {
     <div>
       {step === 1 && <Step1 onNext={handleNext} />}
       {step === 2 && <Step2 onNext={handleNext} />}
-      {step === 3 && <Step3 onNext={handleNext} />}
-      {step === 4 && <SurveyComplete />}
+      {/* {step === 3 && <Step3 onNext={handleNext} />} */}
+      {step === 3 && <SurveyComplete />}
     </div>
   );
 }

--- a/src/app/survey/page.tsx
+++ b/src/app/survey/page.tsx
@@ -13,8 +13,7 @@ import { usePageStayTracker } from '@hooks/usePageStayTracker';
 
 function SurveyFlow() {
   const [step, setStep] = useState<1 | 2 | 3 | 4>(1);
-  const { selectedPlatforms, selectedGenres, watchedContents } =
-    useSurveyContext();
+  const { selectedPlatforms, selectedGenres } = useSurveyContext();
 
   const handleNext = async () => {
     if (step < 2) {
@@ -24,7 +23,7 @@ function SurveyFlow() {
         await postSurvey({
           platforms: selectedPlatforms,
           genres: selectedGenres,
-          contentIds: watchedContents,
+          // contentIds: watchedContents,
         });
         setStep(3); // 성공 시 완료 페이지로 이동
       } catch {

--- a/src/lib/platforms.ts
+++ b/src/lib/platforms.ts
@@ -7,5 +7,5 @@ export const PLATFORMS: Platform[] = [
   { label: '웨이브', id: 'wavve' },
   { label: '디즈니+', id: 'disneyPlus' },
   { label: '왓챠', id: 'watcha' },
-  { label: 'Apple TV', id: 'appleTV' },
+  { label: 'Apple TV', id: 'appleTv' },
 ];

--- a/src/types/survey/Survey.ts
+++ b/src/types/survey/Survey.ts
@@ -1,5 +1,5 @@
 export interface PostSurveyRequest {
   platforms: string[];
   genres: string[];
-  contentIds: number[];
+  contentIds?: number[];
 }


### PR DESCRIPTION
## 📝작업 내용
- 1, 2차 MVP 때는 사용자 Survey를 받을 때, contentID는 받지 않음 -> 구독 OTT 및 장르만 받도록 수정
- `Survey.ts`의 `PostSurveyRequest`에서 contentIds 값은 선택적 필드로 지정 -> 콘텐츠 선택은 "건너뛰기"가 가능하기에 수정한 부분
- lib/platforms.ts 에서 `appleTV`로 맵핑 되어있던 것을 `appleTv`로 변경 (배포 환경에서는 파일 대소문자 구분을 확실하게 해야 하다고 합니다!!)

## 💬리뷰 요구사항
- 급하게 수정한 부분에 대해서 오류가 있다면 확인해 주시면 감사하겠습니다 :)

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
