### PR TITLE
hotfix: 설문조사 step3에서 콘텐츠 목록 안보이는 문제 해결

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -221,6 +221,21 @@
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
+
+  .visible-scroll {
+    scrollbar-width: auto; /* Firefox */
+    -ms-overflow-style: auto; /* IE 10+ */
+  }
+
+  .visible-scroll::-webkit-scrollbar {
+    display: block;
+    width: 6px; /* 원하는 너비 */
+  }
+
+  .visible-scroll::-webkit-scrollbar-thumb {
+    background-color: rgba(255, 255, 255, 0.4); /* 스크롤 색상 */
+    border-radius: 6px;
+  }
 }
 
 @layer utilities {

--- a/src/components/survey/Step2.tsx
+++ b/src/components/survey/Step2.tsx
@@ -61,7 +61,10 @@ export default function Step2({ onNext }: Step2Props) {
         </h2>
 
         {/* 스크롤 가능한 선택 영역 */}
-        <div className="overflow-y-auto w-full" style={{ maxHeight: '500px' }}>
+        <div
+          className="overflow-y-auto w-full visible-scroll"
+          style={{ maxHeight: '500px' }}
+        >
           <div className="grid grid-cols-3 gap-y-6 px-4">
             {GENRES.map(({ label, id }) => (
               <CircleOption

--- a/src/components/survey/Step3.tsx
+++ b/src/components/survey/Step3.tsx
@@ -58,7 +58,10 @@ export default function Step3({ onNext }: Step3Props) {
         </h2>
 
         {/* 스크롤 가능한 포스터 목록 */}
-        <div className="overflow-y-auto w-full" style={{ maxHeight: '500px' }}>
+        <div
+          className="overflow-y-auto w-full visible-scroll"
+          style={{ maxHeight: '500px' }}
+        >
           <div className="grid grid-cols-3 gap-6 px-4">
             {isLoaded
               ? randomContents.map(({ contentId, title, posterUrl }, idx) => (

--- a/src/components/survey/Step3.tsx
+++ b/src/components/survey/Step3.tsx
@@ -21,10 +21,17 @@ export default function Step3({ onNext }: Step3Props) {
   const { watchedContents, setWatchedContents } = useSurveyContext();
   const [randomContents] = useState(() => getRandomContents(9));
   const [loadedCount, setLoadedCount] = useState(0);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+
+  useEffect(() => {
+    if (loadedCount === randomContents.length) {
+      setIsLoaded(true);
+    }
+  }, [loadedCount, randomContents.length]);
 
   const toggleContent = (contentId: number) => {
     const updated = watchedContents.includes(contentId)
@@ -53,36 +60,37 @@ export default function Step3({ onNext }: Step3Props) {
         {/* 스크롤 가능한 포스터 목록 */}
         <div className="overflow-y-auto w-full" style={{ maxHeight: '500px' }}>
           <div className="grid grid-cols-3 gap-6 px-4">
-            {randomContents.map(({ contentId, title, posterUrl }, idx) => {
-              const isLoaded = loadedCount > idx;
-
-              return (
-                <div key={`${contentId}-${idx}`}>
-                  {!isLoaded ? (
-                    <Skeleton className="w-[100px] h-[150px]" />
-                  ) : (
-                    <SurveyPosterCard
-                      title={title}
-                      image={posterUrl}
-                      selected={watchedContents.includes(contentId)}
-                      onClick={() => toggleContent(contentId)}
-                    />
-                  )}
-                  <Image
-                    src={posterUrl}
-                    alt=""
-                    width={100}
-                    height={150}
-                    onLoad={handleImageLoad}
-                    className="hidden"
+            {isLoaded
+              ? randomContents.map(({ contentId, title, posterUrl }, idx) => (
+                  <SurveyPosterCard
+                    key={`${contentId}-${idx}`}
+                    title={title}
+                    image={posterUrl}
+                    selected={watchedContents.includes(contentId)}
+                    onClick={() => toggleContent(contentId)}
                   />
-                </div>
-              );
-            })}
+                ))
+              : Array.from({ length: 9 }).map((_, idx) => (
+                  <Skeleton key={idx} className="w-[100px] h-[150px]" />
+                ))}
+
+            {/* 이미지 preload (invisible로 로드 트리거) */}
+            {!isLoaded &&
+              randomContents.map(({ posterUrl }, idx) => (
+                <Image
+                  key={`preload-${idx}`}
+                  src={posterUrl}
+                  alt=""
+                  width={100}
+                  height={150}
+                  onLoad={handleImageLoad}
+                  className="invisible absolute w-[1px] h-[1px]"
+                />
+              ))}
           </div>
         </div>
 
-        {/* 하단 버튼 두 개 - 아래 고정 + 간격 확보 */}
+        {/* 하단 버튼 */}
         <div className="mt-auto pt-10 flex justify-center gap-6">
           <Button
             onClick={onNext}

--- a/src/components/survey/SurveyPosterCard.tsx
+++ b/src/components/survey/SurveyPosterCard.tsx
@@ -31,7 +31,13 @@ export function SurveyPosterCard({
       }
     >
       <div className="relative w-full aspect-[2/3]">
-        <Image src={image} alt={title} fill className="object-cover" />
+        <Image
+          src={image}
+          alt={title}
+          fill
+          sizes="(max-width: 768px) 100vw, 33vw"
+          className="object-cover"
+        />
       </div>
     </div>
   );

--- a/src/components/survey/SurveyPosterCard.tsx
+++ b/src/components/survey/SurveyPosterCard.tsx
@@ -7,7 +7,6 @@ interface SurveyPosterCardProps {
   image: string;
   selected?: boolean;
   onClick: () => void;
-  onImageLoad?: () => void;
 }
 
 export function SurveyPosterCard({
@@ -15,7 +14,6 @@ export function SurveyPosterCard({
   image,
   selected = false,
   onClick,
-  onImageLoad,
 }: SurveyPosterCardProps) {
   return (
     <div
@@ -33,13 +31,7 @@ export function SurveyPosterCard({
       }
     >
       <div className="relative w-full aspect-[2/3]">
-        <Image
-          src={image}
-          alt={title}
-          onLoad={onImageLoad}
-          fill
-          className="object-cover"
-        />
+        <Image src={image} alt={title} fill className="object-cover" />
       </div>
     </div>
   );

--- a/src/components/survey/mockContents.ts
+++ b/src/components/survey/mockContents.ts
@@ -1,1052 +1,1052 @@
 export const MOCK_CONTENTS = [
   {
     contentId: 613,
-    genre: 'ACTION',
     title: '올드 가드 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%83%E1%85%B3+%E1%84%80%E1%85%A1%E1%84%83%E1%85%B3+2_poster.webp',
   },
   {
     contentId: 776,
-    genre: 'ACTION',
     title: '케이팝 데몬 헌터스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%86%B8+%E1%84%83%E1%85%A6%E1%84%86%E1%85%A9%E1%86%AB+%E1%84%92%E1%85%A5%E1%86%AB%E1%84%90%E1%85%A5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 567,
-    genre: 'ACTION',
     title: '어브로드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A5%E1%84%87%E1%85%B3%E1%84%85%E1%85%A9%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 65,
-    genre: 'ACTION',
     title: '광장',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%AA%E1%86%BC%E1%84%8C%E1%85%A1%E1%86%BC_poster.webp',
   },
   {
     contentId: 252,
-    genre: 'ACTION',
     title: '드래곤 길들이기',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%B3%E1%84%85%E1%85%A2%E1%84%80%E1%85%A9%E1%86%AB+%E1%84%80%E1%85%B5%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%B5%E1%84%80%E1%85%B5_poster.webp',
   },
   {
     contentId: 76,
-    genre: 'ACTION',
     title: '굿보이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%AE%E1%86%BA%E1%84%87%E1%85%A9%E1%84%8B%E1%85%B5_poster.webp',
   },
   {
     contentId: 860,
-    genre: 'ACTION',
     title: '하이파이브',
     posterUrl:
-      'https://ap-northeast-2.console.aws.amazon.com/s3/object/s3-udt-dev?region=ap-northeast-2&bucketType=general&prefix=poster/%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B3_poster.webp',
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B3_poster.webp',
   },
   {
     contentId: 27,
-    genre: 'ACTION',
     title: 'ONE-하이스쿨 히어로즈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/ONE-%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%89%E1%85%B3%E1%84%8F%E1%85%AE%E1%86%AF+%E1%84%92%E1%85%B5%E1%84%8B%E1%85%A5%E1%84%85%E1%85%A9%E1%84%8C%E1%85%B3_poster.webp',
   },
   {
     contentId: 523,
-    genre: 'ACTION',
     title: '씨너스: 죄인들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%B5%E1%84%82%E1%85%A5%E1%84%89%E1%85%B3%3A+%E1%84%8C%E1%85%AC%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 584,
-    genre: 'ADVENTURE',
     title: '엘리오 | 특별 영상',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%97%98%EB%A6%AC%EC%98%A4+_+%ED%8A%B9%EB%B3%84+%EC%98%81%EC%83%81_poster.webp',
   },
   {
     contentId: 252,
-    genre: 'ADVENTURE',
     title: '드래곤 길들이기',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%B3%E1%84%85%E1%85%A2%E1%84%80%E1%85%A9%E1%86%AB+%E1%84%80%E1%85%B5%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%B5%E1%84%80%E1%85%B5_poster.webp',
   },
   {
     contentId: 102,
-    genre: 'ADVENTURE',
     title: '극장판 닌자보이 란타로: 도쿠타케 닌자대 최강의 군사',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B7%B9%EC%9E%A5%ED%8C%90+%EB%8B%8C%EC%9E%90%EB%B3%B4%EC%9D%B4+%EB%9E%80%ED%83%80%EB%A1%9C_+%EB%8F%84%EC%BF%A0%ED%83%80%EC%BC%80+%EB%8B%8C%EC%9E%90%EB%8C%80+%EC%B5%9C%EA%B0%95%EC%9D%98+%EA%B5%B0%EC%82%AC_poster.webp',
   },
   {
     contentId: 101,
-    genre: 'ADVENTURE',
     title: '극장판 닌자보이 란타로: 도쿠타케 닌자대 최강의 군사',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB%E1%84%82%E1%85%B5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%87%E1%85%A9%E1%84%8B%E1%85%B5%E1%84%85%E1%85%A1%E1%86%AB%E1%84%90%E1%85%A1%E1%84%85%E1%85%A9-%E1%84%83%E1%85%A9%E1%84%8F%E1%85%AE%E1%84%90%E1%85%A1%E1%84%8F%E1%85%A6%E1%84%82%E1%85%B5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%A2%E1%84%8E%E1%85%AC%E1%84%80%E1%85%A1%E1%86%BC%E1%84%8B%E1%85%B4%E1%84%80%E1%85%AE%E1%86%AB%E1%84%89%E1%85%A1_poster.webp',
   },
   {
     contentId: 520,
-    genre: 'ADVENTURE',
     title: '썬더볼츠*',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%A5%E1%86%AB%E1%84%83%E1%85%A5%E1%84%87%E1%85%A9%E1%86%AF%E1%84%8E%E1%85%B3*_poster.webp',
   },
   {
     contentId: 15,
-    genre: 'ADVENTURE',
     title: 'A MINECRAFT MOVIE 마인크래프트 무비',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/A+MINECRAFT+MOVIE+%E1%84%86%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%84%85%E1%85%A2%E1%84%91%E1%85%B3%E1%84%90%E1%85%B3+%E1%84%86%E1%85%AE%E1%84%87%E1%85%B5_poster.webp',
   },
   {
     contentId: 47,
-    genre: 'ADVENTURE',
     title: '간니발 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A1%E1%86%AB%E1%84%82%E1%85%B5%E1%84%87%E1%85%A1%E1%86%AF+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.webp',
   },
   {
     contentId: 844,
-    genre: 'ADVENTURE',
     title: '플로우',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%94%8C%EB%A1%9C%EC%9A%B0_poster.webp',
   },
   {
     contentId: 344,
-    genre: 'ADVENTURE',
     title: '미키 17',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%B5%E1%84%8F%E1%85%B5+17_poster.webp',
   },
   {
     contentId: 776,
-    genre: 'ANIMATION',
     title: '케이팝 데몬 헌터스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%86%B8+%E1%84%83%E1%85%A6%E1%84%86%E1%85%A9%E1%86%AB+%E1%84%92%E1%85%A5%E1%86%AB%E1%84%90%E1%85%A5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 101,
-    genre: 'ANIMATION',
     title: '극장판 닌자보이 란타로: 도쿠타케 닌자대 최강의 군사',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB%E1%84%82%E1%85%B5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%87%E1%85%A9%E1%84%8B%E1%85%B5%E1%84%85%E1%85%A1%E1%86%AB%E1%84%90%E1%85%A1%E1%84%85%E1%85%A9-%E1%84%83%E1%85%A9%E1%84%8F%E1%85%AE%E1%84%90%E1%85%A1%E1%84%8F%E1%85%A6%E1%84%82%E1%85%B5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%A2%E1%84%8E%E1%85%AC%E1%84%80%E1%85%A1%E1%86%BC%E1%84%8B%E1%85%B4%E1%84%80%E1%85%AE%E1%86%AB%E1%84%89%E1%85%A1_poster.webp',
   },
   {
     contentId: 102,
-    genre: 'ANIMATION',
     title: '극장판 닌자보이 란타로: 도쿠타케 닌자대 최강의 군사',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B7%B9%EC%9E%A5%ED%8C%90+%EB%8B%8C%EC%9E%90%EB%B3%B4%EC%9D%B4+%EB%9E%80%ED%83%80%EB%A1%9C_+%EB%8F%84%EC%BF%A0%ED%83%80%EC%BC%80+%EB%8B%8C%EC%9E%90%EB%8C%80+%EC%B5%9C%EA%B0%95%EC%9D%98+%EA%B5%B0%EC%82%AC_poster.webp',
   },
   {
     contentId: 72,
-    genre: 'ANIMATION',
     title: '괴수 8호: 미션 리컨',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B4%B4%EC%88%98+8%ED%98%B8_+%EB%AF%B8%EC%85%98+%EB%A6%AC%EC%BB%A8_poster.webp',
   },
   {
     contentId: 187,
-    genre: 'ANIMATION',
     title: '달팽이의 회고록',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A1%E1%86%AF%E1%84%91%E1%85%A2%E1%86%BC%E1%84%8B%E1%85%B5%E1%84%8B%E1%85%B4+%E1%84%92%E1%85%AC%E1%84%80%E1%85%A9%E1%84%85%E1%85%A9%E1%86%A8_poster.webp',
   },
   {
     contentId: 885,
-    genre: 'ANIMATION',
     title: '화성특급',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%99%94%EC%84%B1%ED%8A%B9%EA%B8%89_poster.webp',
   },
   {
     contentId: 844,
-    genre: 'ANIMATION',
     title: '플로우',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%94%8C%EB%A1%9C%EC%9A%B0_poster.webp',
   },
   {
     contentId: 60,
-    genre: 'ANIMATION',
     title: '고스트캣 앙주',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A9%E1%84%89%E1%85%B3%E1%84%90%E1%85%B3%E1%84%8F%E1%85%A2%E1%86%BA+%E1%84%8B%E1%85%A1%E1%86%BC%E1%84%8C%E1%85%AE_poster.webp',
   },
   {
     contentId: 403,
-    genre: 'ANIMATION',
     title: '뽀로로 극장판 바닷속 대모험',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%88%E1%85%A9%E1%84%85%E1%85%A9%E1%84%85%E1%85%A9+%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB+%E1%84%87%E1%85%A1%E1%84%83%E1%85%A1%E1%86%BA%E1%84%89%E1%85%A9%E1%86%A8+%E1%84%83%E1%85%A2%E1%84%86%E1%85%A9%E1%84%92%E1%85%A5%E1%86%B7_poster.webp',
   },
   {
     contentId: 322,
-    genre: 'COMEDY',
     title: '목요일 살인 클럽',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A9%E1%86%A8%E1%84%8B%E1%85%AD%E1%84%8B%E1%85%B5%E1%86%AF%E1%84%89%E1%85%A1%E1%86%AF%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8_poster.webp',
   },
   {
     contentId: 610,
-    genre: 'COMEDY',
     title: '옥스퍼드에서의 날들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%A8%E1%84%89%E1%85%B3%E1%84%91%E1%85%A5%E1%84%83%E1%85%B3%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5%E1%84%8B%E1%85%B4%E1%84%82%E1%85%A1%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 874,
-    genre: 'COMEDY',
     title: '향기로운 꽃은 늠름하게 핀다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%96%A5%EA%B8%B0%EB%A1%9C%EC%9A%B4+%EA%BD%83%EC%9D%80+%EB%8A%A0%EB%A6%84%ED%95%98%EA%B2%8C+%ED%95%80%EB%8B%A4_poster.webp',
   },
   {
     contentId: 798,
-    genre: 'COMEDY',
     title: '탐욕에 눈먼 자들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%AD%E1%86%A8%E1%84%8B%E1%85%A6%E1%84%82%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 208,
-    genre: 'COMEDY',
     title: '더 베어 시즌 4',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A5+%E1%84%87%E1%85%A6%E1%84%8B%E1%85%A5+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+4_poster.webp',
   },
   {
     contentId: 427,
-    genre: 'COMEDY',
     title: '살롱 드 홈즈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A1%E1%86%AF%E1%84%85%E1%85%A9%E1%86%BC+%E1%84%83%E1%85%B3+%E1%84%92%E1%85%A9%E1%86%B7%E1%84%8C%E1%85%B3_poster.webp',
   },
   {
     contentId: 76,
-    genre: 'COMEDY',
     title: '굿보이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%AE%E1%86%BA%E1%84%87%E1%85%A9%E1%84%8B%E1%85%B5_poster.webp',
   },
   {
     contentId: 176,
-    genre: 'COMEDY',
     title: '노무사 노무진',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A9%E1%84%86%E1%85%AE%E1%84%89%E1%85%A1+%E1%84%82%E1%85%A9%E1%84%86%E1%85%AE%E1%84%8C%E1%85%B5%E1%86%AB_poster.webp',
   },
   {
     contentId: 646,
-    genre: 'COMEDY',
     title: '이 별에 필요한',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%B4+%EB%B3%84%EC%97%90+%ED%95%84%EC%9A%94%ED%95%9C_poster.webp',
   },
   {
     contentId: 21,
-    genre: 'CONCERT',
     title: 'L1VE WIRE',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/L1VE+WIRE_poster.webp',
   },
   {
     contentId: 354,
-    genre: 'CONCERT',
     title: '방판뮤직: 어디든 가요',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%B0%A9%ED%8C%90%EB%AE%A4%EC%A7%81+%EC%96%B4%EB%94%94%EB%93%A0+%EA%B0%80%EC%9A%94_poster.webp',
   },
   {
     contentId: 798,
-    genre: 'CRIME',
     title: '탐욕에 눈먼 자들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%AD%E1%86%A8%E1%84%8B%E1%85%A6%E1%84%82%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 301,
-    genre: 'CRIME',
     title: '메스를 든 사냥꾼',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A6%E1%84%89%E1%85%B3%E1%84%85%E1%85%B3%E1%86%AF+%E1%84%83%E1%85%B3%E1%86%AB+%E1%84%89%E1%85%A1%E1%84%82%E1%85%A3%E1%86%BC%E1%84%81%E1%85%AE%E1%86%AB_poster.webp',
   },
   {
     contentId: 65,
-    genre: 'CRIME',
     title: '광장',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%AA%E1%86%BC%E1%84%8C%E1%85%A1%E1%86%BC_poster.webp',
   },
   {
     contentId: 27,
-    genre: 'CRIME',
     title: 'ONE-하이스쿨 히어로즈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/ONE-%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%89%E1%85%B3%E1%84%8F%E1%85%AE%E1%86%AF+%E1%84%92%E1%85%B5%E1%84%8B%E1%85%A5%E1%84%85%E1%85%A9%E1%84%8C%E1%85%B3_poster.webp',
   },
   {
     contentId: 408,
-    genre: 'CRIME',
     title: '사건수사대 Q',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A1%E1%84%80%E1%85%A5%E1%86%AB%E1%84%89%E1%85%AE%E1%84%89%E1%85%A1%E1%84%83%E1%85%A2+Q_poster.webp',
   },
   {
     contentId: 835,
-    genre: 'CRIME',
     title: '페니키안 스킴',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%91%E1%85%A6%E1%84%82%E1%85%B5%E1%84%8F%E1%85%B5%E1%84%8B%E1%85%A1%E1%86%AB+%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B5%E1%86%B7_poster.webp',
   },
   {
     contentId: 149,
-    genre: 'CRIME',
     title: '나인 퍼즐',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB+%E1%84%91%E1%85%A5%E1%84%8C%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 436,
-    genre: 'CRIME',
     title: '샤크: 더 스톰',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A3%E1%84%8F%E1%85%B3_+%E1%84%83%E1%85%A5+%E1%84%89%E1%85%B3%E1%84%90%E1%85%A9%E1%86%B7_poster.webp',
   },
   {
     contentId: 520,
-    genre: 'CRIME',
     title: '썬더볼츠*',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%A5%E1%86%AB%E1%84%83%E1%85%A5%E1%84%87%E1%85%A9%E1%86%AF%E1%84%8E%E1%85%B3*_poster.webp',
   },
   {
     contentId: 767,
-    genre: 'DOCUMENTARY',
     title: '카운트다운: 테일러 vs 세라노',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A1%E1%84%8B%E1%85%AE%E1%86%AB%E1%84%90%E1%85%B3%E1%84%83%E1%85%A1%E1%84%8B%E1%85%AE%E1%86%AB_+%E1%84%90%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%AF%E1%84%85%E1%85%A5+vs+%E1%84%89%E1%85%A6%E1%84%85%E1%85%A1%E1%84%82%E1%85%A9_poster.webp',
   },
   {
     contentId: 341,
-    genre: 'DOCUMENTARY',
     title: '미야자키 하야오: 자연의 영혼',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%B5%E1%84%8B%E1%85%A3%E1%84%8C%E1%85%A1%E1%84%8F%E1%85%B5%E1%84%92%E1%85%A1%E1%84%8B%E1%85%A3%E1%84%8B%E1%85%A9-%E1%84%8C%E1%85%A1%E1%84%8B%E1%85%A7%E1%86%AB%E1%84%8B%E1%85%B4%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%92%E1%85%A9%E1%86%AB_poster.webp',
   },
   {
     contentId: 667,
-    genre: 'DOCUMENTARY',
     title: '임영웅│아임 히어로 더 스타디움',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%B5%E1%86%B7%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%8B%E1%85%AE%E1%86%BC%E2%94%82%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%B7%E1%84%92%E1%85%B5%E1%84%8B%E1%85%A5%E1%84%85%E1%85%A9%E1%84%83%E1%85%A5%E1%84%89%E1%85%B3%E1%84%90%E1%85%A1%E1%84%83%E1%85%B5%E1%84%8B%E1%85%AE%E1%86%B7_poster.webp',
   },
   {
     contentId: 578,
-    genre: 'DOCUMENTARY',
     title: '에스파: 월드 투어 인 시네마',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A6%E1%84%89%E1%85%B3%E1%84%91%E1%85%A1-%E1%84%8B%E1%85%AF%E1%86%AF%E1%84%83%E1%85%B3%E1%84%90%E1%85%AE%E1%84%8B%E1%85%A5%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%89%E1%85%B5%E1%84%82%E1%85%A6%E1%84%86%E1%85%A1_poster.jpeg',
   },
   {
     contentId: 262,
-    genre: 'DOCUMENTARY',
     title: '러브 온 더 스펙트럼: 미국 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%9F%AC%EB%B8%8C+%EC%98%A8+%EB%8D%94+%EC%8A%A4%ED%8E%99%ED%8A%B8%EB%9F%BC+%EB%AF%B8%EA%B5%AD+%EC%8B%9C%EC%A6%8C+2_poster.webp',
   },
   {
     contentId: 388,
-    genre: 'DOCUMENTARY',
     title: '블랙2: 영혼파괴자들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%B8%94%EB%9E%992+%EC%98%81%ED%98%BC%ED%8C%8C%EA%B4%B4%EC%9E%90%EB%93%A4_poster.webp',
   },
   {
     contentId: 42,
-    genre: 'DOCUMENTARY',
     title: '가짜사나이 2: 더 메이킹',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B0%80%EC%A7%9C%EC%82%AC%EB%82%98%EC%9D%B4+2+%EB%8D%94+%EB%A9%94%EC%9D%B4%ED%82%B9_poster.webp',
   },
   {
     contentId: 610,
-    genre: 'DRAMA',
     title: '옥스퍼드에서의 날들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%A8%E1%84%89%E1%85%B3%E1%84%91%E1%85%A5%E1%84%83%E1%85%B3%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5%E1%84%8B%E1%85%B4%E1%84%82%E1%85%A1%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 874,
-    genre: 'DRAMA',
     title: '향기로운 꽃은 늠름하게 핀다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%96%A5%EA%B8%B0%EB%A1%9C%EC%9A%B4+%EA%BD%83%EC%9D%80+%EB%8A%A0%EB%A6%84%ED%95%98%EA%B2%8C+%ED%95%80%EB%8B%A4_poster.webp',
   },
   {
     contentId: 902,
-    genre: 'DRAMA',
     title: '히카루가 죽은 여름',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%9E%88%EC%B9%B4%EB%A3%A8%EA%B0%80+%EC%A3%BD%EC%9D%80+%EC%97%AC%EB%A6%84_poster.webp',
   },
   {
     contentId: 745,
-    genre: 'DRAMA',
     title: '첫사랑 DOGs',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8E%E1%85%A5%E1%86%BA%E1%84%89%E1%85%A1%E1%84%85%E1%85%A1%E1%86%BC+DOGs_poster.webp',
   },
   {
     contentId: 606,
-    genre: 'DRAMA',
     title: '오징어 게임 시즌 3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%B5%E1%86%BC%E1%84%8B%E1%85%A5+%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+3_poster.webp',
   },
   {
     contentId: 208,
-    genre: 'DRAMA',
     title: '더 베어 시즌 4',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A5+%E1%84%87%E1%85%A6%E1%84%8B%E1%85%A5+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+4_poster.webp',
   },
   {
     contentId: 534,
-    genre: 'DRAMA',
     title: '아이언하트',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%8B%E1%85%A5%E1%86%AB%E1%84%92%E1%85%A1%E1%84%90%E1%85%B3_poster.webp',
   },
   {
     contentId: 260,
-    genre: 'DRAMA',
     title: '러닝메이트',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%85%E1%85%A5%E1%84%82%E1%85%B5%E1%86%BC%E1%84%86%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%90%E1%85%B3_poster.webp',
   },
   {
     contentId: 125,
-    genre: 'DRAMA',
     title: '기빗올: 우리들의 썸머',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B8%B0%EB%B9%97%EC%98%AC_+%EC%9A%B0%EB%A6%AC%EB%93%A4%EC%9D%98+%EC%8D%B8%EB%A8%B8_poster.webp',
   },
   {
     contentId: 613,
-    genre: 'FANTASY',
     title: '올드 가드 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%83%E1%85%B3+%E1%84%80%E1%85%A1%E1%84%83%E1%85%B3+2_poster.webpp',
   },
   {
     contentId: 776,
-    genre: 'FANTASY',
     title: '케이팝 데몬 헌터스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%86%B8+%E1%84%83%E1%85%A6%E1%84%86%E1%85%A9%E1%86%AB+%E1%84%92%E1%85%A5%E1%86%AB%E1%84%90%E1%85%A5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 153,
-    genre: 'FANTASY',
     title: '남주의 첫날밤을 가져버렸다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A1%E1%86%B7%E1%84%8C%E1%85%AE%E1%84%8B%E1%85%B4+%E1%84%8E%E1%85%A5%E1%86%BA%E1%84%82%E1%85%A1%E1%86%AF%E1%84%87%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%B3%E1%86%AF+%E1%84%80%E1%85%A1%E1%84%8C%E1%85%A7%E1%84%87%E1%85%A5%E1%84%85%E1%85%A7%E1%86%BB%E1%84%83%E1%85%A1_poster.webp',
   },
   {
     contentId: 584,
-    genre: 'FANTASY',
     title: '엘리오 | 특별 영상',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%97%98%EB%A6%AC%EC%98%A4+_+%ED%8A%B9%EB%B3%84+%EC%98%81%EC%83%81_poster.webp',
   },
   {
     contentId: 252,
-    genre: 'FANTASY',
     title: '드래곤 길들이기',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%B3%E1%84%85%E1%85%A2%E1%84%80%E1%85%A9%E1%86%AB+%E1%84%80%E1%85%B5%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%B5%E1%84%80%E1%85%B5_poster.webp',
   },
   {
     contentId: 176,
-    genre: 'FANTASY',
     title: '노무사 노무진',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A9%E1%84%86%E1%85%AE%E1%84%89%E1%85%A1+%E1%84%82%E1%85%A9%E1%84%86%E1%85%AE%E1%84%8C%E1%85%B5%E1%86%AB_poster.webp',
   },
   {
     contentId: 860,
-    genre: 'FANTASY',
     title: '하이파이브',
     posterUrl:
       'https://ap-northeast-2.console.aws.amazon.com/s3/object/s3-udt-dev?region=ap-northeast-2&bucketType=general&prefix=poster/%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B3_poster.webp',
   },
   {
     contentId: 520,
-    genre: 'FANTASY',
     title: '썬더볼츠*',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%A5%E1%86%AB%E1%84%83%E1%85%A5%E1%84%87%E1%85%A9%E1%86%AF%E1%84%8E%E1%85%B3*_poster.webp',
   },
   {
     contentId: 15,
-    genre: 'FANTASY',
     title: 'A MINECRAFT MOVIE 마인크래프트 무비',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/A+MINECRAFT+MOVIE+%E1%84%86%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%84%85%E1%85%A2%E1%84%91%E1%85%B3%E1%84%90%E1%85%B3+%E1%84%86%E1%85%AE%E1%84%87%E1%85%B5_poster.webp',
   },
   {
     contentId: 796,
-    genre: 'HISTORICAL_DRAMA',
     title: '탄금',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%AB%E1%84%80%E1%85%B3%E1%86%B7_poster.webp',
   },
   {
     contentId: 79,
-    genre: 'HISTORICAL_DRAMA',
     title: '귀궁',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B1%E1%84%80%E1%85%AE%E1%86%BC_poster.webp',
   },
   {
     contentId: 837,
-    genre: 'HISTORICAL_DRAMA',
     title: '폭싹 속았수다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%91%E1%85%A9%E1%86%A8%E1%84%8A%E1%85%A1%E1%86%A8+%E1%84%89%E1%85%A9%E1%86%A8%E1%84%8B%E1%85%A1%E1%86%BB%E1%84%89%E1%85%AE%E1%84%83%E1%85%A1_poster.webp',
   },
   {
     contentId: 855,
-    genre: 'HISTORICAL_DRAMA',
     title: '하얼빈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A1%E1%84%8B%E1%85%A5%E1%86%AF%E1%84%87%E1%85%B5%E1%86%AB_poster.webp',
   },
   {
     contentId: 681,
-    genre: 'HISTORICAL_DRAMA',
     title: '정년이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8C%E1%85%A5%E1%86%BC%E1%84%82%E1%85%A7%E1%86%AB%E1%84%8B%E1%85%B5_poster.webp',
   },
   {
     contentId: 831,
-    genre: 'HISTORICAL_DRAMA',
     title: '파친코 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%91%E1%85%A1%E1%84%8E%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%A9+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.png',
   },
   {
     contentId: 439,
-    genre: 'HISTORICAL_DRAMA',
     title: '서울의 봄',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A5%E1%84%8B%E1%85%AE%E1%86%AF%E1%84%8B%E1%85%B4%E1%84%87%E1%85%A9%E1%86%B7_poster.webp',
   },
   {
     contentId: 884,
-    genre: 'HISTORICAL_DRAMA',
     title: '혼례대첩',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A9%E1%86%AB%E1%84%85%E1%85%A8%E1%84%83%E1%85%A2%E1%84%8E%E1%85%A5%E1%86%B8_poster.webp',
   },
   {
     contentId: 600,
-    genre: 'HISTORICAL_DRAMA',
     title: '오아시스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8B%E1%85%A1%E1%84%89%E1%85%B5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 902,
-    genre: 'HORROR',
     title: '히카루가 죽은 여름',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%9E%88%EC%B9%B4%EB%A3%A8%EA%B0%80+%EC%A3%BD%EC%9D%80+%EC%97%AC%EB%A6%84_poster.webp',
   },
   {
     contentId: 606,
-    genre: 'HORROR',
     title: '오징어 게임 시즌 3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%B5%E1%86%BC%E1%84%8B%E1%85%A5+%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+3_poster.webp',
   },
   {
     contentId: 523,
-    genre: 'HORROR',
     title: '씨너스: 죄인들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%B5%E1%84%82%E1%85%A5%E1%84%89%E1%85%B3%3A+%E1%84%8C%E1%85%AC%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 828,
-    genre: 'HORROR',
     title: '파이널 데스티네이션 블러드라인',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%91%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%82%E1%85%A5%E1%86%AF+%E1%84%83%E1%85%A6%E1%84%89%E1%85%B3%E1%84%90%E1%85%B5%E1%84%82%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%89%E1%85%A7%E1%86%AB+%E1%84%87%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%84%83%E1%85%B3%E1%84%85%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB_poster.webp',
   },
   {
     contentId: 877,
-    genre: 'HORROR',
     title: '헤레틱',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A6%E1%84%85%E1%85%A6%E1%84%90%E1%85%B5%E1%86%A8_poster.webp',
   },
   {
     contentId: 59,
-    genre: 'HORROR',
     title: '계시록',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A8%E1%84%89%E1%85%B5%E1%84%85%E1%85%A9%E1%86%A8_poster.webp',
   },
   {
     contentId: 47,
-    genre: 'HORROR',
     title: '간니발 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A1%E1%86%AB%E1%84%82%E1%85%B5%E1%84%87%E1%85%A1%E1%86%AF+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.webp',
   },
   {
     contentId: 813,
-    genre: 'HORROR',
     title: '퇴마록',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%87%B4%EB%A7%88%EB%A1%9D_poster.webp',
   },
   {
     contentId: 605,
-    genre: 'HORROR',
     title: '오징어 게임 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%B5%E1%86%BC%E1%84%8B%E1%85%A5+%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.webp',
   },
   {
     contentId: 60,
-    genre: 'KIDS',
     title: '고스트캣 앙주',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A9%E1%84%89%E1%85%B3%E1%84%90%E1%85%B3%E1%84%8F%E1%85%A2%E1%86%BA+%E1%84%8B%E1%85%A1%E1%86%BC%E1%84%8C%E1%85%AE_poster.webp',
   },
   {
     contentId: 403,
-    genre: 'KIDS',
     title: '뽀로로 극장판 바닷속 대모험',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%88%E1%85%A9%E1%84%85%E1%85%A9%E1%84%85%E1%85%A9+%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB+%E1%84%87%E1%85%A1%E1%84%83%E1%85%A1%E1%86%BA%E1%84%89%E1%85%A9%E1%86%A8+%E1%84%83%E1%85%A2%E1%84%86%E1%85%A9%E1%84%92%E1%85%A5%E1%86%B7_poster.webp',
   },
   {
     contentId: 404,
-    genre: 'KIDS',
     title: '뽀로로 극장판: 슈퍼스타 대모험',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%88%E1%85%A9%E1%84%85%E1%85%A9%E1%84%85%E1%85%A9+%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB-+%E1%84%89%E1%85%B2%E1%84%91%E1%85%A5%E1%84%89%E1%85%B3%E1%84%90%E1%85%A1+%E1%84%83%E1%85%A2%E1%84%86%E1%85%A9%E1%84%92%E1%85%A5%E1%86%B7_poster.webp',
   },
   {
     contentId: 879,
-    genre: 'KIDS',
     title: '헬로 카봇 13기 젬',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A6%E1%86%AF%E1%84%85%E1%85%A9+%E1%84%8F%E1%85%A1%E1%84%87%E1%85%A9%E1%86%BA+13%E1%84%80%E1%85%B5+%E1%84%8C%E1%85%A6%E1%86%B7_poster.webp',
   },
   {
     contentId: 118,
-    genre: 'KIDS',
     title: '극장판 헬로카봇: 수상한 마술단의 비밀',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB+%E1%84%92%E1%85%A6%E1%86%AF%E1%84%85%E1%85%A9%E1%84%8F%E1%85%A1%E1%84%87%E1%85%A9%E1%86%BA-+%E1%84%89%E1%85%AE%E1%84%89%E1%85%A1%E1%86%BC%E1%84%92%E1%85%A1%E1%86%AB+%E1%84%86%E1%85%A1%E1%84%89%E1%85%AE%E1%86%AF%E1%84%83%E1%85%A1%E1%86%AB%E1%84%8B%E1%85%B4+%E1%84%87%E1%85%B5%E1%84%86%E1%85%B5%E1%86%AF_poster.webp',
   },
   {
     contentId: 776,
-    genre: 'MUSICAL',
     title: '케이팝 데몬 헌터스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%86%B8+%E1%84%83%E1%85%A6%E1%84%86%E1%85%A9%E1%86%AB+%E1%84%92%E1%85%A5%E1%86%AB%E1%84%90%E1%85%A5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 328,
-    genre: 'MUSICAL',
     title: '무파사: 라이온 킹',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%AC%B4%ED%8C%8C%EC%82%AC_+%EB%9D%BC%EC%9D%B4%EC%98%A8+%ED%82%B9_poster.webp',
   },
   {
     contentId: 638,
-    genre: 'MUSICAL',
     title: '위키드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%B1%E1%84%8F%E1%85%B5%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 417,
-    genre: 'MUSICAL',
     title: '사랑의 하츄핑',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%82%AC%EB%9E%91%EC%9D%98+%ED%95%98%EC%B8%84%ED%95%91_poster.webp',
   },
   {
     contentId: 633,
-    genre: 'MUSICAL',
     title: '웡카',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%AF%E1%86%BC%E1%84%8F%E1%85%A1_poster.webp',
   },
   {
     contentId: 636,
-    genre: 'MUSICAL',
     title: '위시',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9C%84%EC%8B%9C_poster.webp',
   },
   {
     contentId: 127,
-    genre: 'MUSICAL',
     title: '기예르모 델토로의 피노키오',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B5%E1%84%8B%E1%85%A8%E1%84%85%E1%85%B3%E1%84%86%E1%85%A9+%E1%84%83%E1%85%A6%E1%86%AF%E1%84%90%E1%85%A9%E1%84%85%E1%85%A9%E1%84%8B%E1%85%B4+%E1%84%91%E1%85%B5%E1%84%82%E1%85%A9%E1%84%8F%E1%85%B5%E1%84%8B%E1%85%A9_poster.webp',
   },
   {
     contentId: 524,
-    genre: 'MUSICAL',
     title: '씽2게더',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%B5%E1%86%BC2%E1%84%80%E1%85%A6%E1%84%83%E1%85%A5_poster.webp',
   },
   {
     contentId: 322,
-    genre: 'MYSTERY',
     title: '목요일 살인 클럽',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A9%E1%86%A8%E1%84%8B%E1%85%AD%E1%84%8B%E1%85%B5%E1%86%AF%E1%84%89%E1%85%A1%E1%86%AF%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8_poster.webp',
   },
   {
     contentId: 387,
-    genre: 'MYSTERY',
     title: '브릭',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%87%E1%85%B3%E1%84%85%E1%85%B5%E1%86%A8_poster.webp',
   },
   {
     contentId: 902,
-    genre: 'MYSTERY',
     title: '히카루가 죽은 여름',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%9E%88%EC%B9%B4%EB%A3%A8%EA%B0%80+%EC%A3%BD%EC%9D%80+%EC%97%AC%EB%A6%84_poster.webp',
   },
   {
     contentId: 798,
-    genre: 'MYSTERY',
     title: '탐욕에 눈먼 자들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%AD%E1%86%A8%E1%84%8B%E1%85%A6%E1%84%82%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 427,
-    genre: 'MYSTERY',
     title: '살롱 드 홈즈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A1%E1%86%AF%E1%84%85%E1%85%A9%E1%86%BC+%E1%84%83%E1%85%B3+%E1%84%92%E1%85%A9%E1%86%B7%E1%84%8C%E1%85%B3_poster.webp',
   },
   {
     contentId: 245,
-    genre: 'MYSTERY',
     title: '동지: 너에게 닿은 계절',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A9%E1%86%BC%E1%84%8C%E1%85%B5_+%E1%84%82%E1%85%A5%E1%84%8B%E1%85%A6%E1%84%80%E1%85%A6+%E1%84%83%E1%85%A1%E1%87%82%E1%84%8B%E1%85%B3%E1%86%AB+%E1%84%80%E1%85%A8%E1%84%8C%E1%85%A5%E1%86%AF_poster.webp',
   },
   {
     contentId: 408,
-    genre: 'MYSTERY',
     title: '사건수사대 Q',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A1%E1%84%80%E1%85%A5%E1%86%AB%E1%84%89%E1%85%AE%E1%84%89%E1%85%A1%E1%84%83%E1%85%A2+Q_poster.webp',
   },
   {
     contentId: 149,
-    genre: 'MYSTERY',
     title: '나인 퍼즐',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB+%E1%84%91%E1%85%A5%E1%84%8C%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 796,
-    genre: 'MYSTERY',
     title: '탄금',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%AB%E1%84%80%E1%85%B3%E1%86%B7_poster.webp',
   },
   {
     contentId: 624,
-    genre: 'REALITY',
     title: '우리는 잉꼬부부가 아닙니다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9A%B0%EB%A6%AC%EB%8A%94+%EC%9E%89%EA%BC%AC%EB%B6%80%EB%B6%80%EA%B0%80+%EC%95%84%EB%8B%99%EB%8B%88%EB%8B%A4_poster.webp',
   },
   {
     contentId: 672,
-    genre: 'REALITY',
     title: '장도바리바리',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9E%A5%EB%8F%84%EB%B0%94%EB%A6%AC%EB%B0%94%EB%A6%AC_poster.webp',
   },
   {
     contentId: 687,
-    genre: 'REALITY',
     title: '제철남자',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%A0%9C%EC%B2%A0%EB%82%A8%EC%9E%90_poster.webp',
   },
   {
     contentId: 666,
-    genre: 'REALITY',
     title: '일타맘',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%BC%ED%83%80%EB%A7%98_poster.webp',
   },
   {
     contentId: 603,
-    genre: 'REALITY',
     title: '오은영 스테이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%98%A4%EC%9D%80%EC%98%81+%EC%8A%A4%ED%85%8C%EC%9D%B4_poster.webp',
   },
   {
     contentId: 598,
-    genre: 'REALITY',
     title: '오래된 만남 추구 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%98%A4%EB%9E%98%EB%90%9C+%EB%A7%8C%EB%82%A8+%EC%B6%94%EA%B5%AC+%EC%8B%9C%EC%A6%8C+2_poster.webp',
   },
   {
     contentId: 136,
-    genre: 'REALITY',
     title: '나나민박 with 세븐틴',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%82%98%EB%82%98%EB%AF%BC%EB%B0%95+with+%EC%84%B8%EB%B8%90%ED%8B%B4_poster.webp',
   },
   {
     contentId: 354,
-    genre: 'REALITY',
     title: '방판뮤직: 어디든 가요',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%B0%A9%ED%8C%90%EB%AE%A4%EC%A7%81+%EC%96%B4%EB%94%94%EB%93%A0+%EA%B0%80%EC%9A%94_poster.webp',
   },
   {
     contentId: 631,
-    genre: 'REALITY',
     title: '월드 오브 스트릿 우먼 파이터',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9B%94%EB%93%9C+%EC%98%A4%EB%B8%8C+%EC%8A%A4%ED%8A%B8%EB%A6%BF+%EC%9A%B0%EB%A8%BC+%ED%8C%8C%EC%9D%B4%ED%84%B0_poster.jpg',
   },
   {
     contentId: 610,
-    genre: 'ROMANCE',
     title: '옥스퍼드에서의 날들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%A8%E1%84%89%E1%85%B3%E1%84%91%E1%85%A5%E1%84%83%E1%85%B3%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5%E1%84%8B%E1%85%B4%E1%84%82%E1%85%A1%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 874,
-    genre: 'ROMANCE',
     title: '향기로운 꽃은 늠름하게 핀다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%96%A5%EA%B8%B0%EB%A1%9C%EC%9A%B4+%EA%BD%83%EC%9D%80+%EB%8A%A0%EB%A6%84%ED%95%98%EA%B2%8C+%ED%95%80%EB%8B%A4_poster.webp',
   },
   {
     contentId: 625,
-    genre: 'ROMANCE',
     title: '우리영화',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%AE%E1%84%85%E1%85%B5%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%92%E1%85%AA_poster.webp',
   },
   {
     contentId: 153,
-    genre: 'ROMANCE',
     title: '남주의 첫날밤을 가져버렸다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A1%E1%86%B7%E1%84%8C%E1%85%AE%E1%84%8B%E1%85%B4+%E1%84%8E%E1%85%A5%E1%86%BA%E1%84%82%E1%85%A1%E1%86%AF%E1%84%87%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%B3%E1%86%AF+%E1%84%80%E1%85%A1%E1%84%8C%E1%85%A7%E1%84%87%E1%85%A5%E1%84%85%E1%85%A7%E1%86%BB%E1%84%83%E1%85%A1_poster.webp',
   },
   {
     contentId: 12,
-    genre: 'ROMANCE',
     title: '366일',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/366%E1%84%8B%E1%85%B5%E1%86%AF_poster.webp',
   },
   {
     contentId: 245,
-    genre: 'ROMANCE',
     title: '동지: 너에게 닿은 계절',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A9%E1%86%BC%E1%84%8C%E1%85%B5_+%E1%84%82%E1%85%A5%E1%84%8B%E1%85%A6%E1%84%80%E1%85%A6+%E1%84%83%E1%85%A1%E1%87%82%E1%84%8B%E1%85%B3%E1%86%AB+%E1%84%80%E1%85%A8%E1%84%8C%E1%85%A5%E1%86%AF_poster.webp',
   },
   {
     contentId: 567,
-    genre: 'ROMANCE',
     title: '어브로드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A5%E1%84%87%E1%85%B3%E1%84%85%E1%85%A9%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 646,
-    genre: 'ROMANCE',
     title: '이 별에 필요한',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%B4+%EB%B3%84%EC%97%90+%ED%95%84%EC%9A%94%ED%95%9C_poster.webp',
   },
   {
     contentId: 342,
-    genre: 'ROMANCE',
     title: '미지의 서울',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%B5%E1%84%8C%E1%85%B5%E1%84%8B%E1%85%B4+%E1%84%89%E1%85%A5%E1%84%8B%E1%85%AE%E1%86%AF_poster.webp',
   },
   {
     contentId: 387,
-    genre: 'SF',
     title: '브릭',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%87%E1%85%B3%E1%84%85%E1%85%B5%E1%86%A8_poster.webp',
   },
   {
     contentId: 646,
-    genre: 'SF',
     title: '이 별에 필요한',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%B4+%EB%B3%84%EC%97%90+%ED%95%84%EC%9A%94%ED%95%9C_poster.webp',
   },
   {
     contentId: 520,
-    genre: 'SF',
     title: '썬더볼츠*',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%A5%E1%86%AB%E1%84%83%E1%85%A5%E1%84%87%E1%85%A9%E1%86%AF%E1%84%8E%E1%85%B3*_poster.webp',
   },
   {
     contentId: 774,
-    genre: 'SF',
     title: '컴패니언',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A5%E1%86%B7%E1%84%91%E1%85%A2%E1%84%82%E1%85%B5%E1%84%8B%E1%85%A5%E1%86%AB_poster.webp',
   },
   {
     contentId: 344,
-    genre: 'SF',
     title: '미키 17',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%B5%E1%84%8F%E1%85%B5+17_poster.webp',
   },
   {
     contentId: 771,
-    genre: 'SF',
     title: '캡틴 아메리카: 브레이브 뉴 월드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A2%E1%86%B8%E1%84%90%E1%85%B5%E1%86%AB+%E1%84%8B%E1%85%A1%E1%84%86%E1%85%A6%E1%84%85%E1%85%B5%E1%84%8F%E1%85%A1-%E1%84%87%E1%85%B3%E1%84%85%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B3+%E1%84%82%E1%85%B2+%E1%84%8B%E1%85%AF%E1%86%AF%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 306,
-    genre: 'SF',
     title: '명탐정 코난 2025',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A7%E1%86%BC%E1%84%90%E1%85%A1%E1%86%B7%E1%84%8C%E1%85%A5%E1%86%BC+%E1%84%8F%E1%85%A9%E1%84%82%E1%85%A1%E1%86%AB+2025_poster.webp',
   },
   {
     contentId: 451,
-    genre: 'SF',
     title: '세브란스: 단절 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A6%E1%84%87%E1%85%B3%E1%84%85%E1%85%A1%E1%86%AB%E1%84%89%E1%85%B3_+%E1%84%83%E1%85%A1%E1%86%AB%E1%84%8C%E1%85%A5%E1%86%AF+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.webp',
   },
   {
     contentId: 135,
-    genre: 'SF',
     title: '나 혼자만 레벨업 -ARISE FROM THE SHADOW-',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%82%98+%ED%98%BC%EC%9E%90%EB%A7%8C+%EB%A0%88%EB%B2%A8%EC%97%85+-ARISE+FROM+THE+SHADOW-_poster.webp',
   },
   {
     contentId: 635,
-    genre: 'SURVIVAL',
     title: '위대한쇼: 태권',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9C%84%EB%8C%80%ED%95%9C%EC%87%BC+%ED%83%9C%EA%B6%8C_poster.webp',
   },
   {
     contentId: 631,
-    genre: 'SURVIVAL',
     title: '월드 오브 스트릿 우먼 파이터',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9B%94%EB%93%9C+%EC%98%A4%EB%B8%8C+%EC%8A%A4%ED%8A%B8%EB%A6%BF+%EC%9A%B0%EB%A8%BC+%ED%8C%8C%EC%9D%B4%ED%84%B0_poster.jpg',
   },
   {
     contentId: 233,
-    genre: 'SURVIVAL',
     title: '데블스 플랜: 데스룸',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%8D%B0%EB%B8%94%EC%8A%A4+%ED%94%8C%EB%9E%9C+%EB%8D%B0%EC%8A%A4%EB%A3%B8_poster.webp',
   },
   {
     contentId: 773,
-    genre: 'SURVIVAL',
     title: '커플팰리스 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%BB%A4%ED%94%8C%ED%8C%B0%EB%A6%AC%EC%8A%A4+2_poster.webp',
   },
   {
     contentId: 452,
-    genre: 'SURVIVAL',
     title: '셀러브리티 베어 헌트',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%85%80%EB%9F%AC%EB%B8%8C%EB%A6%AC%ED%8B%B0+%EB%B2%A0%EC%96%B4+%ED%97%8C%ED%8A%B8_poster.webp',
   },
   {
     contentId: 696,
-    genre: 'SURVIVAL',
     title: '좀비버스: 뉴 블러드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%A2%80%EB%B9%84%EB%B2%84%EC%8A%A4+%EB%89%B4+%EB%B8%94%EB%9F%AC%EB%93%9C_poster.webp',
   },
   {
     contentId: 850,
-    genre: 'SURVIVAL',
     title: '피의 게임 시즌 3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%94%BC%EC%9D%98+%EA%B2%8C%EC%9E%84+%EC%8B%9C%EC%A6%8C+3_poster.webp',
   },
   {
     contentId: 198,
-    genre: 'SURVIVAL',
     title: '대학전쟁 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%8C%80%ED%95%99%EC%A0%84%EC%9F%81+%EC%8B%9C%EC%A6%8C+2.poster.webp',
   },
   {
     contentId: 435,
-    genre: 'SURVIVAL',
     title: '생존왕',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%83%9D%EC%A1%B4%EC%99%95_poster.webp',
   },
   {
     contentId: 519,
-    genre: 'TALK_SHOW',
     title: '심야괴담회 시즌 5',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%8B%AC%EC%95%BC%EA%B4%B4%EB%8B%B4%ED%9A%8C+%EC%8B%9C%EC%A6%8C+5_poster.webp',
   },
   {
     contentId: 666,
-    genre: 'TALK_SHOW',
     title: '일타맘',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%BC%ED%83%80%EB%A7%98_poster.webp',
+  },
+  {
+    contentId: 603,
+    title: '오은영 스테이',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%98%A4%EC%9D%80%EC%98%81+%EC%8A%A4%ED%85%8C%EC%9D%B4_poster.webp',
+  },
+  {
+    contentId: 329,
+    title: '문제적 남자 리부트 수학편',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%AC%B8%EC%A0%9C%EC%A0%81+%EB%82%A8%EC%9E%90+%EB%A6%AC%EB%B6%80%ED%8A%B8++%EC%88%98%ED%95%99%ED%8E%B8_poster.webp',
+  },
+  {
+    contentId: 553,
+    title: '알쓸별잡: 지중해',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%95%8C%EC%93%B8%EB%B3%84%EC%9E%A1+%EC%A7%80%EC%A4%91%ED%95%B4_poster.webp',
+  },
+  {
+    contentId: 212,
+    title: '더 시즌즈 - 박보검의 칸타빌레',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%8D%94+%EC%8B%9C%EC%A6%8C%EC%A6%88+-+%EB%B0%95%EB%B3%B4%EA%B2%80%EC%9D%98+%EC%B9%B8%ED%83%80%EB%B9%8C%EB%A0%88_poster.webp',
+  },
+  {
+    contentId: 585,
+    title: '엠넷 30주년 차트쇼',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%97%A0%EB%84%B7+30%EC%A3%BC%EB%85%84+%EC%B0%A8%ED%8A%B8%EC%87%BC_poster.webp',
+  },
+  {
+    contentId: 679,
+    title: '재친구 시즌 4',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9E%AC%EC%B9%9C%EA%B5%AC+%EC%8B%9C%EC%A6%8C+4_poster.webp',
+  },
+  {
+    contentId: 343,
+    title: '미친맛집: 미식가 친구의 맛집',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%AF%B8%EC%B9%9C%EB%A7%9B%EC%A7%91+%EB%AF%B8%EC%8B%9D%EA%B0%80+%EC%B9%9C%EA%B5%AC%EC%9D%98+%EB%A7%9B%EC%A7%91_poster.webp',
+  },
+  {
+    contentId: 322,
+    title: '목요일 살인 클럽',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A9%E1%86%A8%E1%84%8B%E1%85%AD%E1%84%8B%E1%85%B5%E1%86%AF%E1%84%89%E1%85%A1%E1%86%AF%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8_poster.webp',
+  },
+  {
+    contentId: 387,
+    title: '브릭',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%87%E1%85%B3%E1%84%85%E1%85%B5%E1%86%A8_poster.webp',
+  },
+  {
+    contentId: 606,
+    title: '오징어 게임 시즌 3',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%B5%E1%86%BC%E1%84%8B%E1%85%A5+%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+3_poster.webp',
+  },
+  {
+    contentId: 542,
+    title: '악의 도시',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%B4+%E1%84%83%E1%85%A9%E1%84%89%E1%85%B5_poster.webp',
+  },
+  {
+    contentId: 301,
+    title: '메스를 든 사냥꾼',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A6%E1%84%89%E1%85%B3%E1%84%85%E1%85%B3%E1%86%AF+%E1%84%83%E1%85%B3%E1%86%AB+%E1%84%89%E1%85%A1%E1%84%82%E1%85%A3%E1%86%BC%E1%84%81%E1%85%AE%E1%86%AB_poster.webp',
+  },
+  {
+    contentId: 567,
+    title: '어브로드',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A5%E1%84%87%E1%85%B3%E1%84%85%E1%85%A9%E1%84%83%E1%85%B3_poster.webp',
+  },
+  {
+    contentId: 367,
+    title: '벼랑 끝에 서서',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%87%E1%85%A7%E1%84%85%E1%85%A1%E1%86%BC%E1%84%81%E1%85%B3%E1%87%80%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5%E1%84%89%E1%85%A5_poster.webp',
+  },
+  {
+    contentId: 523,
+    title: '씨너스: 죄인들',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%B5%E1%84%82%E1%85%A5%E1%84%89%E1%85%B3%3A+%E1%84%8C%E1%85%AC%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
+  },
+  {
+    contentId: 703,
+    title: '주차금지',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8C%E1%85%AE%E1%84%8E%E1%85%A1%E1%84%80%E1%85%B3%E1%86%B7%E1%84%8C%E1%85%B5_poster.webp',
+  },
+  {
+    contentId: 618,
+    title: '왔수다 만물트럭',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%99%94%EC%88%98%EB%8B%A4+%EB%A7%8C%EB%AC%BC%ED%8A%B8%EB%9F%AD_poster.webp',
+  },
+  {
+    contentId: 136,
+    title: '나나민박 with 세븐틴',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%82%98%EB%82%98%EB%AF%BC%EB%B0%95+with+%EC%84%B8%EB%B8%90%ED%8B%B4_poster.webp',
+  },
+  {
+    contentId: 594,
+    title: '영자와 세리의 <남겨서 뭐하게>',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%98%81%EC%9E%90%EC%99%80+%EC%84%B8%EB%A6%AC%EC%9D%98+%EB%82%A8%EA%B2%A8%EC%84%9C+%EB%AD%90%ED%95%98%EA%B2%8C_poster.webp',
+  },
+  {
+    contentId: 805,
+    title: '태어난 김에 세계일주4',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%83%9C%EC%96%B4%EB%82%9C+%EA%B9%80%EC%97%90+%EC%84%B8%EA%B3%84%EC%9D%BC%EC%A3%BC4_poster.webp',
+  },
+  {
+    contentId: 705,
+    title: '줄여주는 비서들 2',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%A4%84%EC%97%AC%EC%A3%BC%EB%8A%94+%EB%B9%84%EC%84%9C%EB%93%A4+2_poster.webp',
+  },
+  {
+    contentId: 823,
+    title: '틈만나면, 시즌 3',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%8B%88%EB%A7%8C%EB%82%98%EB%A9%B4%2C+%EC%8B%9C%EC%A6%8C+3_poster.webp',
+  },
+  {
+    contentId: 233,
+    title: '데블스 플랜: 데스룸',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%8D%B0%EB%B8%94%EC%8A%A4+%ED%94%8C%EB%9E%9C+%EB%8D%B0%EC%8A%A4%EB%A3%B8_poster.webp',
+  },
+  {
+    contentId: 626,
+    title: '우리지금만나',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9A%B0%EB%A6%AC%EC%A7%80%EA%B8%88%EB%A7%8C%EB%82%98_poster.webp',
+  },
+  {
+    contentId: 407,
+    title: '뿅뿅 지구오락실3',
+    posterUrl:
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%BF%85%EB%BF%85+%EC%A7%80%EA%B5%AC%EC%98%A4%EB%9D%BD%EC%8B%A43_poster.webp',
   },
 ];

--- a/src/components/survey/mockContents.ts
+++ b/src/components/survey/mockContents.ts
@@ -445,7 +445,7 @@ export const MOCK_CONTENTS = [
     genre: 'FANTASY',
     title: '올드 가드 2',
     posterUrl:
-      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%83%E1%85%B3+%E1%84%80%E1%85%A1%E1%84%83%E1%85%B3+2_poster.webpp',
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%83%E1%85%B3+%E1%84%80%E1%85%A1%E1%84%83%E1%85%B3+2_poster.webp',
   },
   {
     contentId: 776,

--- a/src/components/survey/mockContents.ts
+++ b/src/components/survey/mockContents.ts
@@ -1,1050 +1,1225 @@
 export const MOCK_CONTENTS = [
   {
     contentId: 613,
+    genre: 'ACTION',
     title: '올드 가드 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%83%E1%85%B3+%E1%84%80%E1%85%A1%E1%84%83%E1%85%B3+2_poster.webp',
   },
   {
     contentId: 776,
+    genre: 'ACTION',
     title: '케이팝 데몬 헌터스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%86%B8+%E1%84%83%E1%85%A6%E1%84%86%E1%85%A9%E1%86%AB+%E1%84%92%E1%85%A5%E1%86%AB%E1%84%90%E1%85%A5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 567,
+    genre: 'ACTION',
     title: '어브로드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A5%E1%84%87%E1%85%B3%E1%84%85%E1%85%A9%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 65,
+    genre: 'ACTION',
     title: '광장',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%AA%E1%86%BC%E1%84%8C%E1%85%A1%E1%86%BC_poster.webp',
   },
   {
     contentId: 252,
+    genre: 'ACTION',
     title: '드래곤 길들이기',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%B3%E1%84%85%E1%85%A2%E1%84%80%E1%85%A9%E1%86%AB+%E1%84%80%E1%85%B5%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%B5%E1%84%80%E1%85%B5_poster.webp',
   },
   {
     contentId: 76,
+    genre: 'ACTION',
     title: '굿보이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%AE%E1%86%BA%E1%84%87%E1%85%A9%E1%84%8B%E1%85%B5_poster.webp',
   },
   {
     contentId: 860,
+    genre: 'ACTION',
     title: '하이파이브',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B3_poster.webp',
   },
   {
     contentId: 27,
+    genre: 'ACTION',
     title: 'ONE-하이스쿨 히어로즈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/ONE-%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%89%E1%85%B3%E1%84%8F%E1%85%AE%E1%86%AF+%E1%84%92%E1%85%B5%E1%84%8B%E1%85%A5%E1%84%85%E1%85%A9%E1%84%8C%E1%85%B3_poster.webp',
   },
   {
     contentId: 523,
+    genre: 'ACTION',
     title: '씨너스: 죄인들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%B5%E1%84%82%E1%85%A5%E1%84%89%E1%85%B3%3A+%E1%84%8C%E1%85%AC%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 584,
+    genre: 'ADVENTURE',
     title: '엘리오 | 특별 영상',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%97%98%EB%A6%AC%EC%98%A4+_+%ED%8A%B9%EB%B3%84+%EC%98%81%EC%83%81_poster.webp',
   },
   {
     contentId: 252,
+    genre: 'ADVENTURE',
     title: '드래곤 길들이기',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%B3%E1%84%85%E1%85%A2%E1%84%80%E1%85%A9%E1%86%AB+%E1%84%80%E1%85%B5%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%B5%E1%84%80%E1%85%B5_poster.webp',
   },
   {
     contentId: 102,
+    genre: 'ADVENTURE',
     title: '극장판 닌자보이 란타로: 도쿠타케 닌자대 최강의 군사',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B7%B9%EC%9E%A5%ED%8C%90+%EB%8B%8C%EC%9E%90%EB%B3%B4%EC%9D%B4+%EB%9E%80%ED%83%80%EB%A1%9C_+%EB%8F%84%EC%BF%A0%ED%83%80%EC%BC%80+%EB%8B%8C%EC%9E%90%EB%8C%80+%EC%B5%9C%EA%B0%95%EC%9D%98+%EA%B5%B0%EC%82%AC_poster.webp',
   },
   {
     contentId: 101,
+    genre: 'ADVENTURE',
     title: '극장판 닌자보이 란타로: 도쿠타케 닌자대 최강의 군사',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB%E1%84%82%E1%85%B5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%87%E1%85%A9%E1%84%8B%E1%85%B5%E1%84%85%E1%85%A1%E1%86%AB%E1%84%90%E1%85%A1%E1%84%85%E1%85%A9-%E1%84%83%E1%85%A9%E1%84%8F%E1%85%AE%E1%84%90%E1%85%A1%E1%84%8F%E1%85%A6%E1%84%82%E1%85%B5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%A2%E1%84%8E%E1%85%AC%E1%84%80%E1%85%A1%E1%86%BC%E1%84%8B%E1%85%B4%E1%84%80%E1%85%AE%E1%86%AB%E1%84%89%E1%85%A1_poster.webp',
   },
   {
     contentId: 520,
+    genre: 'ADVENTURE',
     title: '썬더볼츠*',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%A5%E1%86%AB%E1%84%83%E1%85%A5%E1%84%87%E1%85%A9%E1%86%AF%E1%84%8E%E1%85%B3*_poster.webp',
   },
   {
     contentId: 15,
+    genre: 'ADVENTURE',
     title: 'A MINECRAFT MOVIE 마인크래프트 무비',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/A+MINECRAFT+MOVIE+%E1%84%86%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%84%85%E1%85%A2%E1%84%91%E1%85%B3%E1%84%90%E1%85%B3+%E1%84%86%E1%85%AE%E1%84%87%E1%85%B5_poster.webp',
   },
   {
     contentId: 47,
+    genre: 'ADVENTURE',
     title: '간니발 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A1%E1%86%AB%E1%84%82%E1%85%B5%E1%84%87%E1%85%A1%E1%86%AF+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.webp',
   },
   {
     contentId: 844,
+    genre: 'ADVENTURE',
     title: '플로우',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%94%8C%EB%A1%9C%EC%9A%B0_poster.webp',
   },
   {
     contentId: 344,
+    genre: 'ADVENTURE',
     title: '미키 17',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%B5%E1%84%8F%E1%85%B5+17_poster.webp',
   },
   {
     contentId: 776,
+    genre: 'ANIMATION',
     title: '케이팝 데몬 헌터스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%86%B8+%E1%84%83%E1%85%A6%E1%84%86%E1%85%A9%E1%86%AB+%E1%84%92%E1%85%A5%E1%86%AB%E1%84%90%E1%85%A5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 101,
+    genre: 'ANIMATION',
     title: '극장판 닌자보이 란타로: 도쿠타케 닌자대 최강의 군사',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB%E1%84%82%E1%85%B5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%87%E1%85%A9%E1%84%8B%E1%85%B5%E1%84%85%E1%85%A1%E1%86%AB%E1%84%90%E1%85%A1%E1%84%85%E1%85%A9-%E1%84%83%E1%85%A9%E1%84%8F%E1%85%AE%E1%84%90%E1%85%A1%E1%84%8F%E1%85%A6%E1%84%82%E1%85%B5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%A2%E1%84%8E%E1%85%AC%E1%84%80%E1%85%A1%E1%86%BC%E1%84%8B%E1%85%B4%E1%84%80%E1%85%AE%E1%86%AB%E1%84%89%E1%85%A1_poster.webp',
   },
   {
     contentId: 102,
+    genre: 'ANIMATION',
     title: '극장판 닌자보이 란타로: 도쿠타케 닌자대 최강의 군사',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B7%B9%EC%9E%A5%ED%8C%90+%EB%8B%8C%EC%9E%90%EB%B3%B4%EC%9D%B4+%EB%9E%80%ED%83%80%EB%A1%9C_+%EB%8F%84%EC%BF%A0%ED%83%80%EC%BC%80+%EB%8B%8C%EC%9E%90%EB%8C%80+%EC%B5%9C%EA%B0%95%EC%9D%98+%EA%B5%B0%EC%82%AC_poster.webp',
   },
   {
     contentId: 72,
+    genre: 'ANIMATION',
     title: '괴수 8호: 미션 리컨',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B4%B4%EC%88%98+8%ED%98%B8_+%EB%AF%B8%EC%85%98+%EB%A6%AC%EC%BB%A8_poster.webp',
   },
   {
     contentId: 187,
+    genre: 'ANIMATION',
     title: '달팽이의 회고록',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A1%E1%86%AF%E1%84%91%E1%85%A2%E1%86%BC%E1%84%8B%E1%85%B5%E1%84%8B%E1%85%B4+%E1%84%92%E1%85%AC%E1%84%80%E1%85%A9%E1%84%85%E1%85%A9%E1%86%A8_poster.webp',
   },
   {
     contentId: 885,
+    genre: 'ANIMATION',
     title: '화성특급',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%99%94%EC%84%B1%ED%8A%B9%EA%B8%89_poster.webp',
   },
   {
     contentId: 844,
+    genre: 'ANIMATION',
     title: '플로우',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%94%8C%EB%A1%9C%EC%9A%B0_poster.webp',
   },
   {
     contentId: 60,
+    genre: 'ANIMATION',
     title: '고스트캣 앙주',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A9%E1%84%89%E1%85%B3%E1%84%90%E1%85%B3%E1%84%8F%E1%85%A2%E1%86%BA+%E1%84%8B%E1%85%A1%E1%86%BC%E1%84%8C%E1%85%AE_poster.webp',
   },
   {
     contentId: 403,
+    genre: 'ANIMATION',
     title: '뽀로로 극장판 바닷속 대모험',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%88%E1%85%A9%E1%84%85%E1%85%A9%E1%84%85%E1%85%A9+%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB+%E1%84%87%E1%85%A1%E1%84%83%E1%85%A1%E1%86%BA%E1%84%89%E1%85%A9%E1%86%A8+%E1%84%83%E1%85%A2%E1%84%86%E1%85%A9%E1%84%92%E1%85%A5%E1%86%B7_poster.webp',
   },
   {
     contentId: 322,
+    genre: 'COMEDY',
     title: '목요일 살인 클럽',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A9%E1%86%A8%E1%84%8B%E1%85%AD%E1%84%8B%E1%85%B5%E1%86%AF%E1%84%89%E1%85%A1%E1%86%AF%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8_poster.webp',
   },
   {
     contentId: 610,
+    genre: 'COMEDY',
     title: '옥스퍼드에서의 날들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%A8%E1%84%89%E1%85%B3%E1%84%91%E1%85%A5%E1%84%83%E1%85%B3%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5%E1%84%8B%E1%85%B4%E1%84%82%E1%85%A1%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 874,
+    genre: 'COMEDY',
     title: '향기로운 꽃은 늠름하게 핀다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%96%A5%EA%B8%B0%EB%A1%9C%EC%9A%B4+%EA%BD%83%EC%9D%80+%EB%8A%A0%EB%A6%84%ED%95%98%EA%B2%8C+%ED%95%80%EB%8B%A4_poster.webp',
   },
   {
     contentId: 798,
+    genre: 'COMEDY',
     title: '탐욕에 눈먼 자들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%AD%E1%86%A8%E1%84%8B%E1%85%A6%E1%84%82%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 208,
+    genre: 'COMEDY',
     title: '더 베어 시즌 4',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A5+%E1%84%87%E1%85%A6%E1%84%8B%E1%85%A5+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+4_poster.webp',
   },
   {
     contentId: 427,
+    genre: 'COMEDY',
     title: '살롱 드 홈즈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A1%E1%86%AF%E1%84%85%E1%85%A9%E1%86%BC+%E1%84%83%E1%85%B3+%E1%84%92%E1%85%A9%E1%86%B7%E1%84%8C%E1%85%B3_poster.webp',
   },
   {
     contentId: 76,
+    genre: 'COMEDY',
     title: '굿보이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%AE%E1%86%BA%E1%84%87%E1%85%A9%E1%84%8B%E1%85%B5_poster.webp',
   },
   {
     contentId: 176,
+    genre: 'COMEDY',
     title: '노무사 노무진',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A9%E1%84%86%E1%85%AE%E1%84%89%E1%85%A1+%E1%84%82%E1%85%A9%E1%84%86%E1%85%AE%E1%84%8C%E1%85%B5%E1%86%AB_poster.webp',
   },
   {
     contentId: 646,
+    genre: 'COMEDY',
     title: '이 별에 필요한',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%B4+%EB%B3%84%EC%97%90+%ED%95%84%EC%9A%94%ED%95%9C_poster.webp',
   },
   {
     contentId: 21,
+    genre: 'CONCERT',
     title: 'L1VE WIRE',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/L1VE+WIRE_poster.webp',
   },
   {
     contentId: 354,
+    genre: 'CONCERT',
     title: '방판뮤직: 어디든 가요',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%B0%A9%ED%8C%90%EB%AE%A4%EC%A7%81+%EC%96%B4%EB%94%94%EB%93%A0+%EA%B0%80%EC%9A%94_poster.webp',
   },
   {
     contentId: 798,
+    genre: 'CRIME',
     title: '탐욕에 눈먼 자들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%AD%E1%86%A8%E1%84%8B%E1%85%A6%E1%84%82%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 301,
+    genre: 'CRIME',
     title: '메스를 든 사냥꾼',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A6%E1%84%89%E1%85%B3%E1%84%85%E1%85%B3%E1%86%AF+%E1%84%83%E1%85%B3%E1%86%AB+%E1%84%89%E1%85%A1%E1%84%82%E1%85%A3%E1%86%BC%E1%84%81%E1%85%AE%E1%86%AB_poster.webp',
   },
   {
     contentId: 65,
+    genre: 'CRIME',
     title: '광장',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%AA%E1%86%BC%E1%84%8C%E1%85%A1%E1%86%BC_poster.webp',
   },
   {
     contentId: 27,
+    genre: 'CRIME',
     title: 'ONE-하이스쿨 히어로즈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/ONE-%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%89%E1%85%B3%E1%84%8F%E1%85%AE%E1%86%AF+%E1%84%92%E1%85%B5%E1%84%8B%E1%85%A5%E1%84%85%E1%85%A9%E1%84%8C%E1%85%B3_poster.webp',
   },
   {
     contentId: 408,
+    genre: 'CRIME',
     title: '사건수사대 Q',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A1%E1%84%80%E1%85%A5%E1%86%AB%E1%84%89%E1%85%AE%E1%84%89%E1%85%A1%E1%84%83%E1%85%A2+Q_poster.webp',
   },
   {
     contentId: 835,
+    genre: 'CRIME',
     title: '페니키안 스킴',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%91%E1%85%A6%E1%84%82%E1%85%B5%E1%84%8F%E1%85%B5%E1%84%8B%E1%85%A1%E1%86%AB+%E1%84%89%E1%85%B3%E1%84%8F%E1%85%B5%E1%86%B7_poster.webp',
   },
   {
     contentId: 149,
+    genre: 'CRIME',
     title: '나인 퍼즐',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB+%E1%84%91%E1%85%A5%E1%84%8C%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 436,
+    genre: 'CRIME',
     title: '샤크: 더 스톰',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A3%E1%84%8F%E1%85%B3_+%E1%84%83%E1%85%A5+%E1%84%89%E1%85%B3%E1%84%90%E1%85%A9%E1%86%B7_poster.webp',
   },
   {
     contentId: 520,
+    genre: 'CRIME',
     title: '썬더볼츠*',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%A5%E1%86%AB%E1%84%83%E1%85%A5%E1%84%87%E1%85%A9%E1%86%AF%E1%84%8E%E1%85%B3*_poster.webp',
   },
   {
     contentId: 767,
+    genre: 'DOCUMENTARY',
     title: '카운트다운: 테일러 vs 세라노',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A1%E1%84%8B%E1%85%AE%E1%86%AB%E1%84%90%E1%85%B3%E1%84%83%E1%85%A1%E1%84%8B%E1%85%AE%E1%86%AB_+%E1%84%90%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%AF%E1%84%85%E1%85%A5+vs+%E1%84%89%E1%85%A6%E1%84%85%E1%85%A1%E1%84%82%E1%85%A9_poster.webp',
   },
   {
     contentId: 341,
+    genre: 'DOCUMENTARY',
     title: '미야자키 하야오: 자연의 영혼',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%B5%E1%84%8B%E1%85%A3%E1%84%8C%E1%85%A1%E1%84%8F%E1%85%B5%E1%84%92%E1%85%A1%E1%84%8B%E1%85%A3%E1%84%8B%E1%85%A9-%E1%84%8C%E1%85%A1%E1%84%8B%E1%85%A7%E1%86%AB%E1%84%8B%E1%85%B4%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%92%E1%85%A9%E1%86%AB_poster.webp',
   },
   {
     contentId: 667,
+    genre: 'DOCUMENTARY',
     title: '임영웅│아임 히어로 더 스타디움',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%B5%E1%86%B7%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%8B%E1%85%AE%E1%86%BC%E2%94%82%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%B7%E1%84%92%E1%85%B5%E1%84%8B%E1%85%A5%E1%84%85%E1%85%A9%E1%84%83%E1%85%A5%E1%84%89%E1%85%B3%E1%84%90%E1%85%A1%E1%84%83%E1%85%B5%E1%84%8B%E1%85%AE%E1%86%B7_poster.webp',
   },
   {
     contentId: 578,
+    genre: 'DOCUMENTARY',
     title: '에스파: 월드 투어 인 시네마',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A6%E1%84%89%E1%85%B3%E1%84%91%E1%85%A1-%E1%84%8B%E1%85%AF%E1%86%AF%E1%84%83%E1%85%B3%E1%84%90%E1%85%AE%E1%84%8B%E1%85%A5%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%89%E1%85%B5%E1%84%82%E1%85%A6%E1%84%86%E1%85%A1_poster.jpeg',
   },
   {
     contentId: 262,
+    genre: 'DOCUMENTARY',
     title: '러브 온 더 스펙트럼: 미국 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%9F%AC%EB%B8%8C+%EC%98%A8+%EB%8D%94+%EC%8A%A4%ED%8E%99%ED%8A%B8%EB%9F%BC+%EB%AF%B8%EA%B5%AD+%EC%8B%9C%EC%A6%8C+2_poster.webp',
   },
   {
     contentId: 388,
+    genre: 'DOCUMENTARY',
     title: '블랙2: 영혼파괴자들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%B8%94%EB%9E%992+%EC%98%81%ED%98%BC%ED%8C%8C%EA%B4%B4%EC%9E%90%EB%93%A4_poster.webp',
   },
   {
     contentId: 42,
+    genre: 'DOCUMENTARY',
     title: '가짜사나이 2: 더 메이킹',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B0%80%EC%A7%9C%EC%82%AC%EB%82%98%EC%9D%B4+2+%EB%8D%94+%EB%A9%94%EC%9D%B4%ED%82%B9_poster.webp',
   },
   {
     contentId: 610,
+    genre: 'DRAMA',
     title: '옥스퍼드에서의 날들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%A8%E1%84%89%E1%85%B3%E1%84%91%E1%85%A5%E1%84%83%E1%85%B3%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5%E1%84%8B%E1%85%B4%E1%84%82%E1%85%A1%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 874,
+    genre: 'DRAMA',
     title: '향기로운 꽃은 늠름하게 핀다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%96%A5%EA%B8%B0%EB%A1%9C%EC%9A%B4+%EA%BD%83%EC%9D%80+%EB%8A%A0%EB%A6%84%ED%95%98%EA%B2%8C+%ED%95%80%EB%8B%A4_poster.webp',
   },
   {
     contentId: 902,
+    genre: 'DRAMA',
     title: '히카루가 죽은 여름',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%9E%88%EC%B9%B4%EB%A3%A8%EA%B0%80+%EC%A3%BD%EC%9D%80+%EC%97%AC%EB%A6%84_poster.webp',
   },
   {
     contentId: 745,
+    genre: 'DRAMA',
     title: '첫사랑 DOGs',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8E%E1%85%A5%E1%86%BA%E1%84%89%E1%85%A1%E1%84%85%E1%85%A1%E1%86%BC+DOGs_poster.webp',
   },
   {
     contentId: 606,
+    genre: 'DRAMA',
     title: '오징어 게임 시즌 3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%B5%E1%86%BC%E1%84%8B%E1%85%A5+%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+3_poster.webp',
   },
   {
     contentId: 208,
+    genre: 'DRAMA',
     title: '더 베어 시즌 4',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A5+%E1%84%87%E1%85%A6%E1%84%8B%E1%85%A5+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+4_poster.webp',
   },
   {
     contentId: 534,
+    genre: 'DRAMA',
     title: '아이언하트',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%8B%E1%85%A5%E1%86%AB%E1%84%92%E1%85%A1%E1%84%90%E1%85%B3_poster.webp',
   },
   {
     contentId: 260,
+    genre: 'DRAMA',
     title: '러닝메이트',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%85%E1%85%A5%E1%84%82%E1%85%B5%E1%86%BC%E1%84%86%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%90%E1%85%B3_poster.webp',
   },
   {
     contentId: 125,
+    genre: 'DRAMA',
     title: '기빗올: 우리들의 썸머',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EA%B8%B0%EB%B9%97%EC%98%AC_+%EC%9A%B0%EB%A6%AC%EB%93%A4%EC%9D%98+%EC%8D%B8%EB%A8%B8_poster.webp',
   },
   {
     contentId: 613,
+    genre: 'FANTASY',
     title: '올드 가드 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%AF%E1%84%83%E1%85%B3+%E1%84%80%E1%85%A1%E1%84%83%E1%85%B3+2_poster.webpp',
   },
   {
     contentId: 776,
+    genre: 'FANTASY',
     title: '케이팝 데몬 헌터스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%86%B8+%E1%84%83%E1%85%A6%E1%84%86%E1%85%A9%E1%86%AB+%E1%84%92%E1%85%A5%E1%86%AB%E1%84%90%E1%85%A5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 153,
+    genre: 'FANTASY',
     title: '남주의 첫날밤을 가져버렸다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A1%E1%86%B7%E1%84%8C%E1%85%AE%E1%84%8B%E1%85%B4+%E1%84%8E%E1%85%A5%E1%86%BA%E1%84%82%E1%85%A1%E1%86%AF%E1%84%87%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%B3%E1%86%AF+%E1%84%80%E1%85%A1%E1%84%8C%E1%85%A7%E1%84%87%E1%85%A5%E1%84%85%E1%85%A7%E1%86%BB%E1%84%83%E1%85%A1_poster.webp',
   },
   {
     contentId: 584,
+    genre: 'FANTASY',
     title: '엘리오 | 특별 영상',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%97%98%EB%A6%AC%EC%98%A4+_+%ED%8A%B9%EB%B3%84+%EC%98%81%EC%83%81_poster.webp',
   },
   {
     contentId: 252,
+    genre: 'FANTASY',
     title: '드래곤 길들이기',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%B3%E1%84%85%E1%85%A2%E1%84%80%E1%85%A9%E1%86%AB+%E1%84%80%E1%85%B5%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF%E1%84%8B%E1%85%B5%E1%84%80%E1%85%B5_poster.webp',
   },
   {
     contentId: 176,
+    genre: 'FANTASY',
     title: '노무사 노무진',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A9%E1%84%86%E1%85%AE%E1%84%89%E1%85%A1+%E1%84%82%E1%85%A9%E1%84%86%E1%85%AE%E1%84%8C%E1%85%B5%E1%86%AB_poster.webp',
   },
   {
     contentId: 860,
+    genre: 'FANTASY',
     title: '하이파이브',
     posterUrl:
-      'https://ap-northeast-2.console.aws.amazon.com/s3/object/s3-udt-dev?region=ap-northeast-2&bucketType=general&prefix=poster/%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B3_poster.webp',
+      'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B3_poster.webp',
   },
   {
     contentId: 520,
+    genre: 'FANTASY',
     title: '썬더볼츠*',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%A5%E1%86%AB%E1%84%83%E1%85%A5%E1%84%87%E1%85%A9%E1%86%AF%E1%84%8E%E1%85%B3*_poster.webp',
   },
   {
     contentId: 15,
+    genre: 'FANTASY',
     title: 'A MINECRAFT MOVIE 마인크래프트 무비',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/A+MINECRAFT+MOVIE+%E1%84%86%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%84%85%E1%85%A2%E1%84%91%E1%85%B3%E1%84%90%E1%85%B3+%E1%84%86%E1%85%AE%E1%84%87%E1%85%B5_poster.webp',
   },
   {
     contentId: 796,
+    genre: 'HISTORICAL_DRAMA',
     title: '탄금',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%AB%E1%84%80%E1%85%B3%E1%86%B7_poster.webp',
   },
   {
     contentId: 79,
+    genre: 'HISTORICAL_DRAMA',
     title: '귀궁',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B1%E1%84%80%E1%85%AE%E1%86%BC_poster.webp',
   },
   {
     contentId: 837,
+    genre: 'HISTORICAL_DRAMA',
     title: '폭싹 속았수다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%91%E1%85%A9%E1%86%A8%E1%84%8A%E1%85%A1%E1%86%A8+%E1%84%89%E1%85%A9%E1%86%A8%E1%84%8B%E1%85%A1%E1%86%BB%E1%84%89%E1%85%AE%E1%84%83%E1%85%A1_poster.webp',
   },
   {
     contentId: 855,
+    genre: 'HISTORICAL_DRAMA',
     title: '하얼빈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A1%E1%84%8B%E1%85%A5%E1%86%AF%E1%84%87%E1%85%B5%E1%86%AB_poster.webp',
   },
   {
     contentId: 681,
+    genre: 'HISTORICAL_DRAMA',
     title: '정년이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8C%E1%85%A5%E1%86%BC%E1%84%82%E1%85%A7%E1%86%AB%E1%84%8B%E1%85%B5_poster.webp',
   },
   {
     contentId: 831,
+    genre: 'HISTORICAL_DRAMA',
     title: '파친코 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%91%E1%85%A1%E1%84%8E%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%A9+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.png',
   },
   {
     contentId: 439,
+    genre: 'HISTORICAL_DRAMA',
     title: '서울의 봄',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A5%E1%84%8B%E1%85%AE%E1%86%AF%E1%84%8B%E1%85%B4%E1%84%87%E1%85%A9%E1%86%B7_poster.webp',
   },
   {
     contentId: 884,
+    genre: 'HISTORICAL_DRAMA',
     title: '혼례대첩',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A9%E1%86%AB%E1%84%85%E1%85%A8%E1%84%83%E1%85%A2%E1%84%8E%E1%85%A5%E1%86%B8_poster.webp',
   },
   {
     contentId: 600,
+    genre: 'HISTORICAL_DRAMA',
     title: '오아시스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8B%E1%85%A1%E1%84%89%E1%85%B5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 902,
+    genre: 'HORROR',
     title: '히카루가 죽은 여름',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%9E%88%EC%B9%B4%EB%A3%A8%EA%B0%80+%EC%A3%BD%EC%9D%80+%EC%97%AC%EB%A6%84_poster.webp',
   },
   {
     contentId: 606,
+    genre: 'HORROR',
     title: '오징어 게임 시즌 3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%B5%E1%86%BC%E1%84%8B%E1%85%A5+%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+3_poster.webp',
   },
   {
     contentId: 523,
+    genre: 'HORROR',
     title: '씨너스: 죄인들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%B5%E1%84%82%E1%85%A5%E1%84%89%E1%85%B3%3A+%E1%84%8C%E1%85%AC%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 828,
+    genre: 'HORROR',
     title: '파이널 데스티네이션 블러드라인',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%91%E1%85%A1%E1%84%8B%E1%85%B5%E1%84%82%E1%85%A5%E1%86%AF+%E1%84%83%E1%85%A6%E1%84%89%E1%85%B3%E1%84%90%E1%85%B5%E1%84%82%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%89%E1%85%A7%E1%86%AB+%E1%84%87%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%84%83%E1%85%B3%E1%84%85%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB_poster.webp',
   },
   {
     contentId: 877,
+    genre: 'HORROR',
     title: '헤레틱',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A6%E1%84%85%E1%85%A6%E1%84%90%E1%85%B5%E1%86%A8_poster.webp',
   },
   {
     contentId: 59,
+    genre: 'HORROR',
     title: '계시록',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A8%E1%84%89%E1%85%B5%E1%84%85%E1%85%A9%E1%86%A8_poster.webp',
   },
   {
     contentId: 47,
+    genre: 'HORROR',
     title: '간니발 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A1%E1%86%AB%E1%84%82%E1%85%B5%E1%84%87%E1%85%A1%E1%86%AF+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.webp',
   },
   {
     contentId: 813,
+    genre: 'HORROR',
     title: '퇴마록',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%87%B4%EB%A7%88%EB%A1%9D_poster.webp',
   },
   {
     contentId: 605,
+    genre: 'HORROR',
     title: '오징어 게임 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%B5%E1%86%BC%E1%84%8B%E1%85%A5+%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.webp',
   },
   {
     contentId: 60,
+    genre: 'KIDS',
     title: '고스트캣 앙주',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%A9%E1%84%89%E1%85%B3%E1%84%90%E1%85%B3%E1%84%8F%E1%85%A2%E1%86%BA+%E1%84%8B%E1%85%A1%E1%86%BC%E1%84%8C%E1%85%AE_poster.webp',
   },
   {
     contentId: 403,
+    genre: 'KIDS',
     title: '뽀로로 극장판 바닷속 대모험',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%88%E1%85%A9%E1%84%85%E1%85%A9%E1%84%85%E1%85%A9+%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB+%E1%84%87%E1%85%A1%E1%84%83%E1%85%A1%E1%86%BA%E1%84%89%E1%85%A9%E1%86%A8+%E1%84%83%E1%85%A2%E1%84%86%E1%85%A9%E1%84%92%E1%85%A5%E1%86%B7_poster.webp',
   },
   {
     contentId: 404,
+    genre: 'KIDS',
     title: '뽀로로 극장판: 슈퍼스타 대모험',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%88%E1%85%A9%E1%84%85%E1%85%A9%E1%84%85%E1%85%A9+%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB-+%E1%84%89%E1%85%B2%E1%84%91%E1%85%A5%E1%84%89%E1%85%B3%E1%84%90%E1%85%A1+%E1%84%83%E1%85%A2%E1%84%86%E1%85%A9%E1%84%92%E1%85%A5%E1%86%B7_poster.webp',
   },
   {
     contentId: 879,
+    genre: 'KIDS',
     title: '헬로 카봇 13기 젬',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%92%E1%85%A6%E1%86%AF%E1%84%85%E1%85%A9+%E1%84%8F%E1%85%A1%E1%84%87%E1%85%A9%E1%86%BA+13%E1%84%80%E1%85%B5+%E1%84%8C%E1%85%A6%E1%86%B7_poster.webp',
   },
   {
     contentId: 118,
+    genre: 'KIDS',
     title: '극장판 헬로카봇: 수상한 마술단의 비밀',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B3%E1%86%A8%E1%84%8C%E1%85%A1%E1%86%BC%E1%84%91%E1%85%A1%E1%86%AB+%E1%84%92%E1%85%A6%E1%86%AF%E1%84%85%E1%85%A9%E1%84%8F%E1%85%A1%E1%84%87%E1%85%A9%E1%86%BA-+%E1%84%89%E1%85%AE%E1%84%89%E1%85%A1%E1%86%BC%E1%84%92%E1%85%A1%E1%86%AB+%E1%84%86%E1%85%A1%E1%84%89%E1%85%AE%E1%86%AF%E1%84%83%E1%85%A1%E1%86%AB%E1%84%8B%E1%85%B4+%E1%84%87%E1%85%B5%E1%84%86%E1%85%B5%E1%86%AF_poster.webp',
   },
   {
     contentId: 776,
+    genre: 'MUSICAL',
     title: '케이팝 데몬 헌터스',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%91%E1%85%A1%E1%86%B8+%E1%84%83%E1%85%A6%E1%84%86%E1%85%A9%E1%86%AB+%E1%84%92%E1%85%A5%E1%86%AB%E1%84%90%E1%85%A5%E1%84%89%E1%85%B3_poster.webp',
   },
   {
     contentId: 328,
+    genre: 'MUSICAL',
     title: '무파사: 라이온 킹',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%AC%B4%ED%8C%8C%EC%82%AC_+%EB%9D%BC%EC%9D%B4%EC%98%A8+%ED%82%B9_poster.webp',
   },
   {
     contentId: 638,
+    genre: 'MUSICAL',
     title: '위키드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%B1%E1%84%8F%E1%85%B5%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 417,
+    genre: 'MUSICAL',
     title: '사랑의 하츄핑',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%82%AC%EB%9E%91%EC%9D%98+%ED%95%98%EC%B8%84%ED%95%91_poster.webp',
   },
   {
     contentId: 633,
+    genre: 'MUSICAL',
     title: '웡카',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%AF%E1%86%BC%E1%84%8F%E1%85%A1_poster.webp',
   },
   {
     contentId: 636,
+    genre: 'MUSICAL',
     title: '위시',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9C%84%EC%8B%9C_poster.webp',
   },
   {
     contentId: 127,
+    genre: 'MUSICAL',
     title: '기예르모 델토로의 피노키오',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%80%E1%85%B5%E1%84%8B%E1%85%A8%E1%84%85%E1%85%B3%E1%84%86%E1%85%A9+%E1%84%83%E1%85%A6%E1%86%AF%E1%84%90%E1%85%A9%E1%84%85%E1%85%A9%E1%84%8B%E1%85%B4+%E1%84%91%E1%85%B5%E1%84%82%E1%85%A9%E1%84%8F%E1%85%B5%E1%84%8B%E1%85%A9_poster.webp',
   },
   {
     contentId: 524,
+    genre: 'MUSICAL',
     title: '씽2게더',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%B5%E1%86%BC2%E1%84%80%E1%85%A6%E1%84%83%E1%85%A5_poster.webp',
   },
   {
     contentId: 322,
+    genre: 'MYSTERY',
     title: '목요일 살인 클럽',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A9%E1%86%A8%E1%84%8B%E1%85%AD%E1%84%8B%E1%85%B5%E1%86%AF%E1%84%89%E1%85%A1%E1%86%AF%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8_poster.webp',
   },
   {
     contentId: 387,
+    genre: 'MYSTERY',
     title: '브릭',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%87%E1%85%B3%E1%84%85%E1%85%B5%E1%86%A8_poster.webp',
   },
   {
     contentId: 902,
+    genre: 'MYSTERY',
     title: '히카루가 죽은 여름',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%9E%88%EC%B9%B4%EB%A3%A8%EA%B0%80+%EC%A3%BD%EC%9D%80+%EC%97%AC%EB%A6%84_poster.webp',
   },
   {
     contentId: 798,
+    genre: 'MYSTERY',
     title: '탐욕에 눈먼 자들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%AD%E1%86%A8%E1%84%8B%E1%85%A6%E1%84%82%E1%85%AE%E1%86%AB%E1%84%86%E1%85%A5%E1%86%AB%E1%84%8C%E1%85%A1%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 427,
+    genre: 'MYSTERY',
     title: '살롱 드 홈즈',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A1%E1%86%AF%E1%84%85%E1%85%A9%E1%86%BC+%E1%84%83%E1%85%B3+%E1%84%92%E1%85%A9%E1%86%B7%E1%84%8C%E1%85%B3_poster.webp',
   },
   {
     contentId: 245,
+    genre: 'MYSTERY',
     title: '동지: 너에게 닿은 계절',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A9%E1%86%BC%E1%84%8C%E1%85%B5_+%E1%84%82%E1%85%A5%E1%84%8B%E1%85%A6%E1%84%80%E1%85%A6+%E1%84%83%E1%85%A1%E1%87%82%E1%84%8B%E1%85%B3%E1%86%AB+%E1%84%80%E1%85%A8%E1%84%8C%E1%85%A5%E1%86%AF_poster.webp',
   },
   {
     contentId: 408,
+    genre: 'MYSTERY',
     title: '사건수사대 Q',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A1%E1%84%80%E1%85%A5%E1%86%AB%E1%84%89%E1%85%AE%E1%84%89%E1%85%A1%E1%84%83%E1%85%A2+Q_poster.webp',
   },
   {
     contentId: 149,
+    genre: 'MYSTERY',
     title: '나인 퍼즐',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A1%E1%84%8B%E1%85%B5%E1%86%AB+%E1%84%91%E1%85%A5%E1%84%8C%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 796,
+    genre: 'MYSTERY',
     title: '탄금',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%90%E1%85%A1%E1%86%AB%E1%84%80%E1%85%B3%E1%86%B7_poster.webp',
   },
   {
     contentId: 624,
+    genre: 'REALITY',
     title: '우리는 잉꼬부부가 아닙니다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9A%B0%EB%A6%AC%EB%8A%94+%EC%9E%89%EA%BC%AC%EB%B6%80%EB%B6%80%EA%B0%80+%EC%95%84%EB%8B%99%EB%8B%88%EB%8B%A4_poster.webp',
   },
   {
     contentId: 672,
+    genre: 'REALITY',
     title: '장도바리바리',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9E%A5%EB%8F%84%EB%B0%94%EB%A6%AC%EB%B0%94%EB%A6%AC_poster.webp',
   },
   {
     contentId: 687,
+    genre: 'REALITY',
     title: '제철남자',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%A0%9C%EC%B2%A0%EB%82%A8%EC%9E%90_poster.webp',
   },
   {
     contentId: 666,
+    genre: 'REALITY',
     title: '일타맘',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%BC%ED%83%80%EB%A7%98_poster.webp',
   },
   {
     contentId: 603,
+    genre: 'REALITY',
     title: '오은영 스테이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%98%A4%EC%9D%80%EC%98%81+%EC%8A%A4%ED%85%8C%EC%9D%B4_poster.webp',
   },
   {
     contentId: 598,
+    genre: 'REALITY',
     title: '오래된 만남 추구 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%98%A4%EB%9E%98%EB%90%9C+%EB%A7%8C%EB%82%A8+%EC%B6%94%EA%B5%AC+%EC%8B%9C%EC%A6%8C+2_poster.webp',
   },
   {
     contentId: 136,
+    genre: 'REALITY',
     title: '나나민박 with 세븐틴',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%82%98%EB%82%98%EB%AF%BC%EB%B0%95+with+%EC%84%B8%EB%B8%90%ED%8B%B4_poster.webp',
   },
   {
     contentId: 354,
+    genre: 'REALITY',
     title: '방판뮤직: 어디든 가요',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%B0%A9%ED%8C%90%EB%AE%A4%EC%A7%81+%EC%96%B4%EB%94%94%EB%93%A0+%EA%B0%80%EC%9A%94_poster.webp',
   },
   {
     contentId: 631,
+    genre: 'REALITY',
     title: '월드 오브 스트릿 우먼 파이터',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9B%94%EB%93%9C+%EC%98%A4%EB%B8%8C+%EC%8A%A4%ED%8A%B8%EB%A6%BF+%EC%9A%B0%EB%A8%BC+%ED%8C%8C%EC%9D%B4%ED%84%B0_poster.jpg',
   },
   {
     contentId: 610,
+    genre: 'ROMANCE',
     title: '옥스퍼드에서의 날들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%86%A8%E1%84%89%E1%85%B3%E1%84%91%E1%85%A5%E1%84%83%E1%85%B3%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5%E1%84%8B%E1%85%B4%E1%84%82%E1%85%A1%E1%86%AF%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 874,
+    genre: 'ROMANCE',
     title: '향기로운 꽃은 늠름하게 핀다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%96%A5%EA%B8%B0%EB%A1%9C%EC%9A%B4+%EA%BD%83%EC%9D%80+%EB%8A%A0%EB%A6%84%ED%95%98%EA%B2%8C+%ED%95%80%EB%8B%A4_poster.webp',
   },
   {
     contentId: 625,
+    genre: 'ROMANCE',
     title: '우리영화',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%AE%E1%84%85%E1%85%B5%E1%84%8B%E1%85%A7%E1%86%BC%E1%84%92%E1%85%AA_poster.webp',
   },
   {
     contentId: 153,
+    genre: 'ROMANCE',
     title: '남주의 첫날밤을 가져버렸다',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%82%E1%85%A1%E1%86%B7%E1%84%8C%E1%85%AE%E1%84%8B%E1%85%B4+%E1%84%8E%E1%85%A5%E1%86%BA%E1%84%82%E1%85%A1%E1%86%AF%E1%84%87%E1%85%A1%E1%86%B7%E1%84%8B%E1%85%B3%E1%86%AF+%E1%84%80%E1%85%A1%E1%84%8C%E1%85%A7%E1%84%87%E1%85%A5%E1%84%85%E1%85%A7%E1%86%BB%E1%84%83%E1%85%A1_poster.webp',
   },
   {
     contentId: 12,
+    genre: 'ROMANCE',
     title: '366일',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/366%E1%84%8B%E1%85%B5%E1%86%AF_poster.webp',
   },
   {
     contentId: 245,
+    genre: 'ROMANCE',
     title: '동지: 너에게 닿은 계절',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%83%E1%85%A9%E1%86%BC%E1%84%8C%E1%85%B5_+%E1%84%82%E1%85%A5%E1%84%8B%E1%85%A6%E1%84%80%E1%85%A6+%E1%84%83%E1%85%A1%E1%87%82%E1%84%8B%E1%85%B3%E1%86%AB+%E1%84%80%E1%85%A8%E1%84%8C%E1%85%A5%E1%86%AF_poster.webp',
   },
   {
     contentId: 567,
+    genre: 'ROMANCE',
     title: '어브로드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A5%E1%84%87%E1%85%B3%E1%84%85%E1%85%A9%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 646,
+    genre: 'ROMANCE',
     title: '이 별에 필요한',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%B4+%EB%B3%84%EC%97%90+%ED%95%84%EC%9A%94%ED%95%9C_poster.webp',
   },
   {
     contentId: 342,
+    genre: 'ROMANCE',
     title: '미지의 서울',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%B5%E1%84%8C%E1%85%B5%E1%84%8B%E1%85%B4+%E1%84%89%E1%85%A5%E1%84%8B%E1%85%AE%E1%86%AF_poster.webp',
   },
   {
     contentId: 387,
+    genre: 'SF',
     title: '브릭',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%87%E1%85%B3%E1%84%85%E1%85%B5%E1%86%A8_poster.webp',
   },
   {
     contentId: 646,
+    genre: 'SF',
     title: '이 별에 필요한',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%B4+%EB%B3%84%EC%97%90+%ED%95%84%EC%9A%94%ED%95%9C_poster.webp',
   },
   {
     contentId: 520,
+    genre: 'SF',
     title: '썬더볼츠*',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%A5%E1%86%AB%E1%84%83%E1%85%A5%E1%84%87%E1%85%A9%E1%86%AF%E1%84%8E%E1%85%B3*_poster.webp',
   },
   {
     contentId: 774,
+    genre: 'SF',
     title: '컴패니언',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A5%E1%86%B7%E1%84%91%E1%85%A2%E1%84%82%E1%85%B5%E1%84%8B%E1%85%A5%E1%86%AB_poster.webp',
   },
   {
     contentId: 344,
+    genre: 'SF',
     title: '미키 17',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%B5%E1%84%8F%E1%85%B5+17_poster.webp',
   },
   {
     contentId: 771,
+    genre: 'SF',
     title: '캡틴 아메리카: 브레이브 뉴 월드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8F%E1%85%A2%E1%86%B8%E1%84%90%E1%85%B5%E1%86%AB+%E1%84%8B%E1%85%A1%E1%84%86%E1%85%A6%E1%84%85%E1%85%B5%E1%84%8F%E1%85%A1-%E1%84%87%E1%85%B3%E1%84%85%E1%85%A6%E1%84%8B%E1%85%B5%E1%84%87%E1%85%B3+%E1%84%82%E1%85%B2+%E1%84%8B%E1%85%AF%E1%86%AF%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 306,
+    genre: 'SF',
     title: '명탐정 코난 2025',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A7%E1%86%BC%E1%84%90%E1%85%A1%E1%86%B7%E1%84%8C%E1%85%A5%E1%86%BC+%E1%84%8F%E1%85%A9%E1%84%82%E1%85%A1%E1%86%AB+2025_poster.webp',
   },
   {
     contentId: 451,
+    genre: 'SF',
     title: '세브란스: 단절 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%89%E1%85%A6%E1%84%87%E1%85%B3%E1%84%85%E1%85%A1%E1%86%AB%E1%84%89%E1%85%B3_+%E1%84%83%E1%85%A1%E1%86%AB%E1%84%8C%E1%85%A5%E1%86%AF+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+2_poster.webp',
   },
   {
     contentId: 135,
+    genre: 'SF',
     title: '나 혼자만 레벨업 -ARISE FROM THE SHADOW-',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%82%98+%ED%98%BC%EC%9E%90%EB%A7%8C+%EB%A0%88%EB%B2%A8%EC%97%85+-ARISE+FROM+THE+SHADOW-_poster.webp',
   },
   {
     contentId: 635,
+    genre: 'SURVIVAL',
     title: '위대한쇼: 태권',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9C%84%EB%8C%80%ED%95%9C%EC%87%BC+%ED%83%9C%EA%B6%8C_poster.webp',
   },
   {
     contentId: 631,
+    genre: 'SURVIVAL',
     title: '월드 오브 스트릿 우먼 파이터',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9B%94%EB%93%9C+%EC%98%A4%EB%B8%8C+%EC%8A%A4%ED%8A%B8%EB%A6%BF+%EC%9A%B0%EB%A8%BC+%ED%8C%8C%EC%9D%B4%ED%84%B0_poster.jpg',
   },
   {
     contentId: 233,
+    genre: 'SURVIVAL',
     title: '데블스 플랜: 데스룸',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%8D%B0%EB%B8%94%EC%8A%A4+%ED%94%8C%EB%9E%9C+%EB%8D%B0%EC%8A%A4%EB%A3%B8_poster.webp',
   },
   {
     contentId: 773,
+    genre: 'SURVIVAL',
     title: '커플팰리스 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%BB%A4%ED%94%8C%ED%8C%B0%EB%A6%AC%EC%8A%A4+2_poster.webp',
   },
   {
     contentId: 452,
+    genre: 'SURVIVAL',
     title: '셀러브리티 베어 헌트',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%85%80%EB%9F%AC%EB%B8%8C%EB%A6%AC%ED%8B%B0+%EB%B2%A0%EC%96%B4+%ED%97%8C%ED%8A%B8_poster.webp',
   },
   {
     contentId: 696,
+    genre: 'SURVIVAL',
     title: '좀비버스: 뉴 블러드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%A2%80%EB%B9%84%EB%B2%84%EC%8A%A4+%EB%89%B4+%EB%B8%94%EB%9F%AC%EB%93%9C_poster.webp',
   },
   {
     contentId: 850,
+    genre: 'SURVIVAL',
     title: '피의 게임 시즌 3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%94%BC%EC%9D%98+%EA%B2%8C%EC%9E%84+%EC%8B%9C%EC%A6%8C+3_poster.webp',
   },
   {
     contentId: 198,
+    genre: 'SURVIVAL',
     title: '대학전쟁 시즌 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%8C%80%ED%95%99%EC%A0%84%EC%9F%81+%EC%8B%9C%EC%A6%8C+2.poster.webp',
   },
   {
     contentId: 435,
+    genre: 'SURVIVAL',
     title: '생존왕',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%83%9D%EC%A1%B4%EC%99%95_poster.webp',
   },
   {
     contentId: 519,
+    genre: 'TALK_SHOW',
     title: '심야괴담회 시즌 5',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%8B%AC%EC%95%BC%EA%B4%B4%EB%8B%B4%ED%9A%8C+%EC%8B%9C%EC%A6%8C+5_poster.webp',
   },
   {
     contentId: 666,
+    genre: 'TALK_SHOW',
     title: '일타맘',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9D%BC%ED%83%80%EB%A7%98_poster.webp',
   },
   {
     contentId: 603,
+    genre: 'TALK_SHOW',
     title: '오은영 스테이',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%98%A4%EC%9D%80%EC%98%81+%EC%8A%A4%ED%85%8C%EC%9D%B4_poster.webp',
   },
   {
     contentId: 329,
+    genre: 'TALK_SHOW',
     title: '문제적 남자 리부트 수학편',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%AC%B8%EC%A0%9C%EC%A0%81+%EB%82%A8%EC%9E%90+%EB%A6%AC%EB%B6%80%ED%8A%B8++%EC%88%98%ED%95%99%ED%8E%B8_poster.webp',
   },
   {
     contentId: 553,
+    genre: 'TALK_SHOW',
     title: '알쓸별잡: 지중해',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%95%8C%EC%93%B8%EB%B3%84%EC%9E%A1+%EC%A7%80%EC%A4%91%ED%95%B4_poster.webp',
   },
   {
     contentId: 212,
+    genre: 'TALK_SHOW',
     title: '더 시즌즈 - 박보검의 칸타빌레',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%8D%94+%EC%8B%9C%EC%A6%8C%EC%A6%88+-+%EB%B0%95%EB%B3%B4%EA%B2%80%EC%9D%98+%EC%B9%B8%ED%83%80%EB%B9%8C%EB%A0%88_poster.webp',
   },
   {
     contentId: 585,
+    genre: 'TALK_SHOW',
     title: '엠넷 30주년 차트쇼',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%97%A0%EB%84%B7+30%EC%A3%BC%EB%85%84+%EC%B0%A8%ED%8A%B8%EC%87%BC_poster.webp',
   },
   {
     contentId: 679,
+    genre: 'TALK_SHOW',
     title: '재친구 시즌 4',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9E%AC%EC%B9%9C%EA%B5%AC+%EC%8B%9C%EC%A6%8C+4_poster.webp',
   },
   {
     contentId: 343,
+    genre: 'TALK_SHOW',
     title: '미친맛집: 미식가 친구의 맛집',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%AF%B8%EC%B9%9C%EB%A7%9B%EC%A7%91+%EB%AF%B8%EC%8B%9D%EA%B0%80+%EC%B9%9C%EA%B5%AC%EC%9D%98+%EB%A7%9B%EC%A7%91_poster.webp',
   },
   {
     contentId: 322,
+    genre: 'THRILLER',
     title: '목요일 살인 클럽',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A9%E1%86%A8%E1%84%8B%E1%85%AD%E1%84%8B%E1%85%B5%E1%86%AF%E1%84%89%E1%85%A1%E1%86%AF%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%8F%E1%85%B3%E1%86%AF%E1%84%85%E1%85%A5%E1%86%B8_poster.webp',
   },
   {
     contentId: 387,
+    genre: 'THRILLER',
     title: '브릭',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%87%E1%85%B3%E1%84%85%E1%85%B5%E1%86%A8_poster.webp',
   },
   {
     contentId: 606,
+    genre: 'THRILLER',
     title: '오징어 게임 시즌 3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A9%E1%84%8C%E1%85%B5%E1%86%BC%E1%84%8B%E1%85%A5+%E1%84%80%E1%85%A6%E1%84%8B%E1%85%B5%E1%86%B7+%E1%84%89%E1%85%B5%E1%84%8C%E1%85%B3%E1%86%AB+3_poster.webp',
   },
   {
     contentId: 542,
+    genre: 'THRILLER',
     title: '악의 도시',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A1%E1%86%A8%E1%84%8B%E1%85%B4+%E1%84%83%E1%85%A9%E1%84%89%E1%85%B5_poster.webp',
   },
   {
     contentId: 301,
+    genre: 'THRILLER',
     title: '메스를 든 사냥꾼',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%86%E1%85%A6%E1%84%89%E1%85%B3%E1%84%85%E1%85%B3%E1%86%AF+%E1%84%83%E1%85%B3%E1%86%AB+%E1%84%89%E1%85%A1%E1%84%82%E1%85%A3%E1%86%BC%E1%84%81%E1%85%AE%E1%86%AB_poster.webp',
   },
   {
     contentId: 567,
+    genre: 'THRILLER',
     title: '어브로드',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8B%E1%85%A5%E1%84%87%E1%85%B3%E1%84%85%E1%85%A9%E1%84%83%E1%85%B3_poster.webp',
   },
   {
     contentId: 367,
+    genre: 'THRILLER',
     title: '벼랑 끝에 서서',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%87%E1%85%A7%E1%84%85%E1%85%A1%E1%86%BC%E1%84%81%E1%85%B3%E1%87%80%E1%84%8B%E1%85%A6%E1%84%89%E1%85%A5%E1%84%89%E1%85%A5_poster.webp',
   },
   {
     contentId: 523,
+    genre: 'THRILLER',
     title: '씨너스: 죄인들',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8A%E1%85%B5%E1%84%82%E1%85%A5%E1%84%89%E1%85%B3%3A+%E1%84%8C%E1%85%AC%E1%84%8B%E1%85%B5%E1%86%AB%E1%84%83%E1%85%B3%E1%86%AF_poster.webp',
   },
   {
     contentId: 703,
+    genre: 'THRILLER',
     title: '주차금지',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%E1%84%8C%E1%85%AE%E1%84%8E%E1%85%A1%E1%84%80%E1%85%B3%E1%86%B7%E1%84%8C%E1%85%B5_poster.webp',
   },
   {
     contentId: 618,
+    genre: 'VARIETY',
     title: '왔수다 만물트럭',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%99%94%EC%88%98%EB%8B%A4+%EB%A7%8C%EB%AC%BC%ED%8A%B8%EB%9F%AD_poster.webp',
   },
   {
     contentId: 136,
+    genre: 'VARIETY',
     title: '나나민박 with 세븐틴',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%82%98%EB%82%98%EB%AF%BC%EB%B0%95+with+%EC%84%B8%EB%B8%90%ED%8B%B4_poster.webp',
   },
   {
     contentId: 594,
+    genre: 'VARIETY',
     title: '영자와 세리의 <남겨서 뭐하게>',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%98%81%EC%9E%90%EC%99%80+%EC%84%B8%EB%A6%AC%EC%9D%98+%EB%82%A8%EA%B2%A8%EC%84%9C+%EB%AD%90%ED%95%98%EA%B2%8C_poster.webp',
   },
   {
     contentId: 805,
+    genre: 'VARIETY',
     title: '태어난 김에 세계일주4',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%83%9C%EC%96%B4%EB%82%9C+%EA%B9%80%EC%97%90+%EC%84%B8%EA%B3%84%EC%9D%BC%EC%A3%BC4_poster.webp',
   },
   {
     contentId: 705,
+    genre: 'VARIETY',
     title: '줄여주는 비서들 2',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%A4%84%EC%97%AC%EC%A3%BC%EB%8A%94+%EB%B9%84%EC%84%9C%EB%93%A4+2_poster.webp',
   },
   {
     contentId: 823,
+    genre: 'VARIETY',
     title: '틈만나면, 시즌 3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%ED%8B%88%EB%A7%8C%EB%82%98%EB%A9%B4%2C+%EC%8B%9C%EC%A6%8C+3_poster.webp',
   },
   {
     contentId: 233,
+    genre: 'VARIETY',
     title: '데블스 플랜: 데스룸',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%8D%B0%EB%B8%94%EC%8A%A4+%ED%94%8C%EB%9E%9C+%EB%8D%B0%EC%8A%A4%EB%A3%B8_poster.webp',
   },
   {
     contentId: 626,
+    genre: 'VARIETY',
     title: '우리지금만나',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EC%9A%B0%EB%A6%AC%EC%A7%80%EA%B8%88%EB%A7%8C%EB%82%98_poster.webp',
   },
   {
     contentId: 407,
+    genre: 'VARIETY',
     title: '뿅뿅 지구오락실3',
     posterUrl:
       'https://s3-udt-dev.s3.ap-northeast-2.amazonaws.com/poster/%EB%BF%85%EB%BF%85+%EC%A7%80%EA%B5%AC%EC%98%A4%EB%9D%BD%EC%8B%A43_poster.webp',


### PR DESCRIPTION
## #️⃣연관된 이슈 


## 📝작업 내용

- step 3에서 콘텐츠 목록이 안나오고 스켈레톤 ui만 계속 뜨는 문제 해결 (image가 hidden되어있던 문제)
- step2와 step3( 장르, 콘텐츠 목록) 에 스크롤 바 보이도록 변경
- mock data 에서 url 오타 수정 

### 스크린샷 (선택)
![Video_2025_0726_204250](https://github.com/user-attachments/assets/bd89d957-9b2b-47e8-bab1-c008c8580fce)


## 💬리뷰 요구사항(선택)

- 현재 설문조사 step3 에서 콘텐츠 목록을 보여줄 때 장르 불문 랜덤으로 mock data 9개 보여주는 방식인데 step2에서 설문 받은 선호 장르 기반으로 mock data를 보여주는 방식으로 바꿔야 할지 의견 부탁드립니다

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
