### PR TITLE
hotfix: 탐색 페이지 QA 사항 수정

### DIFF
--- a/src/components/explore/ExplorePageCarousel.tsx
+++ b/src/components/explore/ExplorePageCarousel.tsx
@@ -20,6 +20,7 @@ import {
   SheetTitle,
 } from '@components/ui/sheet';
 import { DetailBottomSheetContent } from './DetailBottomSheetContent';
+import { useQueryErrorToast } from '@/hooks/useQueryErrorToast';
 
 interface CarouselProps {
   autoPlayInterval?: number;
@@ -53,7 +54,11 @@ export const ExplorePageCarousel = ({
 
   const draggedContentRef = useRef<RecentContentData | null>(null);
 
-  const { data: contents, status, refetch } = useGetLatestContents();
+  const getLatestContentsQuery = useGetLatestContents();
+  const { data: contents, status, refetch } = getLatestContentsQuery;
+
+  // 에러 발생 시 토스트 띄우기
+  useQueryErrorToast(getLatestContentsQuery);
 
   const extendedMovies = useMemo(() => {
     if (!contents || contents.length === 0) return [];

--- a/src/components/explore/PosterCardScrollBox.tsx
+++ b/src/components/explore/PosterCardScrollBox.tsx
@@ -11,6 +11,7 @@ import { DetailBottomSheetContent } from '@components/explore/DetailBottomSheetC
 import { useGetContentListByBoxType } from '@hooks/explore/useGetContentListByBoxType';
 import { FilterRadioButton } from '@components/explore/FilterRadioButton';
 import { PosterScrollSkeleton } from '@components/explore/PosterScrollBoxSkeleton';
+import { useQueryErrorToast } from '@hooks/useQueryErrorToast';
 
 export interface PosterCardScrollBoxProps {
   BoxTitle: string;
@@ -65,11 +66,11 @@ export const PosterCardScrollBox = ({
   };
 
   // 포스터 스크롤 박스 타입에 따라 콘텐츠 목록 조회 API 호출하는 custom Hook 호출
-  const {
-    data: contentData,
-    status,
-    refetch,
-  } = useGetContentListByBoxType(BoxType);
+  const getContentListByBoxTypeQuery = useGetContentListByBoxType(BoxType);
+  const { data: contentData, status, refetch } = getContentListByBoxTypeQuery;
+
+  // 에러 발생 시 토스트 띄우기
+  useQueryErrorToast(getContentListByBoxTypeQuery);
 
   const handlePosterClick = (movieId: number) => {
     setSelectedMovieId(movieId);

--- a/src/components/explore/PosterCardsGrid.tsx
+++ b/src/components/explore/PosterCardsGrid.tsx
@@ -55,42 +55,51 @@ export const PosterCardsGrid = ({
   }, [loadMoreRef.current, hasNextPage, isFetchingNextPage]);
 
   return (
-    <div className="grid grid-cols-3 sm:grid-cols-4 gap-5 px-4 py-6 mx-auto transition-opacity duration-300">
-      {contents.map((item, idx) => (
-        <PosterCard
-          key={idx}
-          title={item.title}
-          image={item.posterUrl}
-          onClick={() => handlePosterClick(item.contentId)}
-        />
-      ))}
+    <>
+      {contents.length > 0 ? (
+        <>
+          <div className="grid grid-cols-3 sm:grid-cols-4 gap-5 px-4 py-6 mx-auto transition-opacity duration-300">
+            {contents.map((item, idx) => (
+              <PosterCard
+                key={idx}
+                title={item.title}
+                image={item.posterUrl}
+                onClick={() => handlePosterClick(item.contentId)}
+              />
+            ))}
 
-      {/* 로딩 중 표시 */}
-      {isFetchingNextPage && (
-        <div className="col-span-3 text-center py-4">불러오는 중...</div>
-      )}
+            {/* 무한스크롤 트리거용 빈 div */}
+            <div ref={loadMoreRef} className="col-span-3 h-1" />
 
-      {/* 무한스크롤 트리거용 빈 div */}
-      <div ref={loadMoreRef} className="col-span-3 h-1" />
-
-      {/* 영화 상세 정보 BottomSheet (필요 시 pop-up) */}
-      <Sheet
-        open={isDetailBottomSheetOpen}
-        onOpenChange={setIsDetailBottomSheetOpen}
-      >
-        <SheetContent
-          side="bottom"
-          className="px-0 pb-5 h-[90vh] max-w-[640px] w-full mx-auto rounded-t-2xl bg-primary-800 flex flex-col overflow-y-auto scrollbar-hide gap-0"
-        >
-          {/* 표시되지 않는 Header (Screen Reader에서만 읽힘) */}
-          <SheetHeader className="p-0">
-            <SheetTitle className="sr-only h-0 p-0">상세정보</SheetTitle>
-          </SheetHeader>
-          {selectedMovieId && (
-            <DetailBottomSheetContent contentId={selectedMovieId} />
+            {/* 영화 상세 정보 BottomSheet (필요 시 pop-up) */}
+            <Sheet
+              open={isDetailBottomSheetOpen}
+              onOpenChange={setIsDetailBottomSheetOpen}
+            >
+              <SheetContent
+                side="bottom"
+                className="px-0 pb-5 h-[90vh] max-w-[640px] w-full mx-auto rounded-t-2xl bg-primary-800 flex flex-col overflow-y-auto scrollbar-hide gap-0"
+              >
+                {/* 표시되지 않는 Header (Screen Reader에서만 읽힘) */}
+                <SheetHeader className="p-0">
+                  <SheetTitle className="sr-only h-0 p-0">상세정보</SheetTitle>
+                </SheetHeader>
+                {selectedMovieId && (
+                  <DetailBottomSheetContent contentId={selectedMovieId} />
+                )}
+              </SheetContent>
+            </Sheet>
+          </div>
+          {/* 로딩 중 표시 */}
+          {isFetchingNextPage && (
+            <div className="col-span-3 text-center py-4">불러오는 중...</div>
           )}
-        </SheetContent>
-      </Sheet>
-    </div>
+        </>
+      ) : (
+        <div className="w-full h-full flex items-center justify-center text-white">
+          검색 결과가 없습니다.
+        </div>
+      )}
+    </>
   );
 };

--- a/src/constants/FilterData.ts
+++ b/src/constants/FilterData.ts
@@ -7,8 +7,8 @@ export const CONTENT_CATEGORIES = [
 
 export const RATING_OPTIONS = [
   '전체 관람가',
-  '12세 이상',
-  '15세 이상',
+  '12세 이상 관람가',
+  '15세 이상 관람가',
   '청소년 관람불가',
 ] as const;
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -18,8 +18,8 @@ export const CONTENT_CATEGORIES = [
 
 export const RATING_OPTIONS = [
   '전체 관람가',
-  '12세 관람가',
-  '15세 관람가',
+  '12세 이상 관람가',
+  '15세 이상 관람가',
   '청소년 관람불가',
 ] as const;
 

--- a/src/hooks/explore/useGetContentListByBoxType.ts
+++ b/src/hooks/explore/useGetContentListByBoxType.ts
@@ -11,12 +11,10 @@ export const useGetContentListByBoxType = (
   const popularQuery = useGetPopularContents(isPopular); // 인기 콘텐츠 데이터 조회일 때만 수행
   const todayQuery = useGetTodayRecommendContents(isToday); // 오늘의 추천 콘텐츠 데이터 조회일 때만 수행
 
-  const data = isPopular ? popularQuery.data : todayQuery.data; // 포스터 스크롤 박스 타입에 따라 콘텐츠 목록 반환
-  const refetch = isPopular ? popularQuery.refetch : todayQuery.refetch; // 다시 불러오기 함수
-
-  return {
-    data: data || [],
-    status: isPopular ? popularQuery.status : todayQuery.status,
-    refetch,
-  };
+  // 포스터 스크롤 박스 타입에 따라 콘텐츠 목록 조회 API 호출하는 custom Hook 호출
+  if (isPopular) {
+    return popularQuery;
+  } else {
+    return todayQuery;
+  }
 };

--- a/src/hooks/useMutationErrorToast.ts
+++ b/src/hooks/useMutationErrorToast.ts
@@ -1,0 +1,94 @@
+import { useEffect, useRef } from 'react';
+import { UseMutationResult } from '@tanstack/react-query';
+import { showSimpleToast } from '@components/common/Toast';
+import { AxiosError } from 'axios';
+import { handleLogout } from '@lib/handleLogout';
+
+function isAxiosError(error: unknown): error is AxiosError {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'isAxiosError' in error &&
+    (error as AxiosError).isAxiosError === true
+  );
+}
+
+function isAuthReissueError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === '토큰 재발급 실패' ||
+      error.message === '토큰 재발급 중 예상치 못한 오류 발생')
+  );
+}
+
+// Mutation 객체 관련해서 에러 토스트를 띄우기 위한 useMutationErrorToast 훅 (tanstack query의 에러 핸들링에서 용이함을 위함)
+export function useMutationErrorToast<
+  TData = unknown,
+  TError = AxiosError,
+  TVariables = void,
+>(mutation: UseMutationResult<TData, TError, TVariables>, customMsg?: string) {
+  const toastShown = useRef(false);
+
+  useEffect(() => {
+    const isFinalFailure =
+      mutation.isError &&
+      !mutation.isPending && // 실행 중이 아님 = 마지막 실패 후 처리
+      mutation.error &&
+      !toastShown.current;
+
+    if (!isFinalFailure) return;
+
+    toastShown.current = true;
+
+    if (isAuthReissueError(mutation.error)) {
+      handleLogout();
+      return;
+    }
+
+    let statusCode: number | undefined;
+    let errorMsg = '';
+
+    if (isAxiosError(mutation.error)) {
+      statusCode = mutation.error.response?.status;
+    }
+
+    if (customMsg) {
+      errorMsg = customMsg;
+    } else {
+      switch (statusCode) {
+        case 400:
+          errorMsg = '잘못된 요청입니다.';
+          break;
+        case 401:
+          errorMsg = '로그인이 만료되었습니다. 다시 로그인 해주세요.';
+          break;
+        case 403:
+          errorMsg = '권한이 없습니다.';
+          break;
+        case 404:
+          errorMsg = '존재하지 않는 리소스입니다.';
+          break;
+        case 409:
+          errorMsg = '중복된 요청입니다.';
+          break;
+        case 500:
+          errorMsg = '서버 오류가 발생했습니다. 운영팀에 문의 바랍니다.';
+          break;
+        default:
+          errorMsg = '예상치 못한 오류가 발생했습니다.';
+      }
+    }
+
+    showSimpleToast.error({
+      message: errorMsg,
+      position: 'top-center',
+      className:
+        'bg-red-500/70 text-white px-4 py-2 rounded-md mx-auto shadow-lg',
+      duration: 2500,
+    });
+
+    setTimeout(() => {
+      toastShown.current = false;
+    }, 2500);
+  }, [mutation.isError, mutation.error, mutation.isPending, customMsg]);
+}

--- a/src/hooks/useQueryErrorToast.ts
+++ b/src/hooks/useQueryErrorToast.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { QueryObserverResult } from '@tanstack/react-query';
 import { showSimpleToast } from '@components/common/Toast';
 import { AxiosError } from 'axios';
+import { handleLogout } from '@lib/handleLogout';
 
 // 타입가드 함수 사용
 function isAxiosError(error: unknown): error is AxiosError {
@@ -13,6 +14,15 @@ function isAxiosError(error: unknown): error is AxiosError {
   );
 }
 
+// 토큰 재발급 관련 에러 문자열 판별
+function isAuthReissueError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.message === '토큰 재발급 실패' ||
+      error.message === '토큰 재발급 중 예상치 못한 오류 발생') // 둘 중 하나면 토큰 재발급 관련 에러
+  );
+}
+
 // 단일 쿼리에 대해 에러 토스트를 띄울지의 여부를 결정하는 useQueryErrorToast 훅 (tanstack query의 에러 핸들링에서 용이함을 위함)
 export function useQueryErrorToast<TData = unknown, TError = AxiosError>(
   query: QueryObserverResult<TData, TError>,
@@ -21,58 +31,65 @@ export function useQueryErrorToast<TData = unknown, TError = AxiosError>(
   const toastShown = useRef(false); // 토스트 띄운 상태 추적 (중복 발생 방지)
 
   useEffect(() => {
-    if (query.isError && query.error && !toastShown.current) {
-      toastShown.current = true;
+    const isFinalFailure =
+      query.isError && !query.isFetching && query.error && !toastShown.current; // 재시도 중이 아님 = 마지막 실패 후 처리
 
-      // 안전하게 AxiosError만 status, response 접근
-      let statusCode: number | undefined = undefined;
-      let errorMsg: string = '';
+    if (!isFinalFailure) return; // 마지막 실패 후 처리가 아니면 종료
 
-      if (isAxiosError(query.error)) {
-        statusCode = query.error.response?.status;
-      }
-
-      // 각 상황에 따라서 분기 처리 (커스텀 메시지 우선 사용, 없으면 status 값에 따라 메시지 설정)
-      if (customMsg) {
-        errorMsg = customMsg;
-      } else {
-        switch (statusCode) {
-          case 400:
-            errorMsg = '잘못된 요청입니다.';
-            break;
-          case 401:
-            errorMsg = '로그인이 만료되었습니다. 다시 로그인 해주세요.';
-            break;
-          case 403:
-            errorMsg = '권한이 없습니다.';
-            break;
-          case 404:
-            errorMsg = '존재하지 않는 리소스입니다.';
-            break;
-          case 409:
-            errorMsg = '중복된 요청입니다.';
-            break;
-          case 500:
-            errorMsg = '서버 오류가 발생했습니다. 운영팀에 문의 바랍니다.';
-            break;
-          default:
-            // 서버에서 내려주는 message 우선 사용, 없으면 기본 메시지
-            errorMsg = '예상치 못한 오류가 발생했습니다.';
-        }
-      }
-
-      showSimpleToast.error({
-        message: errorMsg,
-        position: 'top-center',
-        className:
-          'bg-red-500/70 text-white px-4 py-2 rounded-md mx-auto shadow-lg',
-        duration: 2500,
-      });
-
-      // 2.5초 후에 토스트 띄운 상태 초기화 (같은 에러 계속 발생할 때마다 토스트가 반복해서 뜰 수 있으니, 그것을 방지하기 위함)
-      setTimeout(() => {
-        toastShown.current = false;
-      }, 2500);
+    // 토큰 재발급 실패에 대한 에러 -> logout 처리
+    if (isAuthReissueError(query.error)) {
+      handleLogout();
+      return;
     }
-  }, [query.isError, query.error, customMsg]);
+
+    // 일반 Axios 에러 처리를 위해 상태 코드 및 메시지 초기화
+    let statusCode: number | undefined;
+    let errorMsg = '';
+
+    if (isAxiosError(query.error)) {
+      statusCode = query.error.response?.status;
+    }
+
+    // 각 상황에 따라서 분기 처리 (커스텀 메시지 우선 사용, 없으면 status 값에 따라 메시지 설정)
+    if (customMsg) {
+      errorMsg = customMsg;
+    } else {
+      switch (statusCode) {
+        case 400:
+          errorMsg = '잘못된 요청입니다.';
+          break;
+        case 401:
+          errorMsg = '로그인이 만료되었습니다. 다시 로그인 해주세요.';
+          break;
+        case 403:
+          errorMsg = '권한이 없습니다.';
+          break;
+        case 404:
+          errorMsg = '존재하지 않는 리소스입니다.';
+          break;
+        case 409:
+          errorMsg = '중복된 요청입니다.';
+          break;
+        case 500:
+          errorMsg = '서버 오류가 발생했습니다. 운영팀에 문의 바랍니다.';
+          break;
+        default:
+          // 서버에서 내려주는 message 우선 사용, 없으면 기본 메시지
+          errorMsg = '예상치 못한 오류가 발생했습니다.';
+      }
+    }
+
+    showSimpleToast.error({
+      message: errorMsg,
+      position: 'top-center',
+      className:
+        'bg-red-500/70 text-white px-4 py-2 rounded-md mx-auto shadow-lg',
+      duration: 2500,
+    });
+
+    // 2.5초 후에 토스트 띄운 상태 초기화 (같은 에러 계속 발생할 때마다 토스트가 반복해서 뜰 수 있으니, 그것을 방지하기 위함)
+    setTimeout(() => {
+      toastShown.current = false;
+    }, 2500);
+  }, [query.isError, query.error, customMsg, query.isFetching]);
 }

--- a/src/lib/handleLogout.ts
+++ b/src/lib/handleLogout.ts
@@ -1,0 +1,17 @@
+import { showSimpleToast } from '@components/common/Toast';
+
+// 로그아웃 처리 함수
+export function handleLogout() {
+  showSimpleToast.error({
+    message: '로그인이 만료되었습니다. 다시 로그인 해주세요.',
+    position: 'top-center',
+    className:
+      'bg-red-500/70 text-white px-4 py-2 rounded-md mx-auto shadow-lg',
+    duration: 2500,
+  });
+
+  // 필요 시 zustand 등 상태 초기화도 진행하면 좋겠네요
+  setTimeout(() => {
+    window.location.href = '/'; // 또는 router.replace('/login')
+  }, 2500);
+}

--- a/src/utils/createFilterRequestParam.ts
+++ b/src/utils/createFilterRequestParam.ts
@@ -41,8 +41,8 @@ const CATEGORY_SETS: Record<
   ]),
   ratings: new Set([
     '전체 관람가',
-    '12세 이상',
-    '15세 이상',
+    '12세 이상 관람가',
+    '15세 이상 관람가',
     '청소년 관람불가',
   ]),
   genres: new Set([


### PR DESCRIPTION
## 📝작업 내용
- `PosterCardsGrid`(필터 선택 후 나오는 그리드) 에서 불러온 정보가 없을 시 "검색 결과가 없습니다" 텍스트 표시
- `PosterCardsGrid` 에서 무한 스크롤 시 "불러오는 중" 텍스트를 화면 가운데에 오도록 배치 수정
- `RATING_OPTIONS` 관련한 정보들에서 명칭 변경 (12세 이상 -> 12세 이상 관람가, 15세 이상 -> 15세 이상 관람가)
- `axiosInstance` 에서 전역 interceptor가 하는 역할로 인해 에러 Toast가 여러 번 뜨는 문제 해결
-  로그아웃을 담당하는 `handleLogout`을 `lib` 폴더에 분리, 각 api 함수에서 로그아웃 로직을 따로 구현하거나, `useQueryErrorToast`에서 불러와 사용하도록 코드 구조 리팩토링
- `useMutation`으로 생성된 Mutation 객체에도 Error 처리와 Error Toast 띄우는 로직을 일원화 하기 위한 `useMutationErrorToast` Hook 추가
- TanStack Query를 사용하는 객체들에 대해, Error 처리를 일원화 하기 위한 `useQueryErrorToast`, `useMutationErrorToast`  Hook에서, 맨 마지막의 retry 에서만 error 처리를 할 수 있도록 로직 수정

## 스크린샷
필터링 시 검색 결과가 없는 경우, 아래와 같이 텍스트를 pop-up 해줍니다.
<img width="377" height="821" alt="스크린샷 2025-07-27 02 41 33" src="https://github.com/user-attachments/assets/eef192e7-2c00-40f1-8689-98b73ddc806d" />

그리고 이젠, 에러 토스트 뜨는 것의 중복 처리가 진행되어, 인증 오류(401)를 포함한 모든 상황에서 Toast는 단 한 번만 발생합니다. (api 함수로만 통신을 진행하는 경우엔, api 함수 자체에서 에러 토스트를 띄우는 로직을 따로 처리해 주셔야 합니다)


https://github.com/user-attachments/assets/fbd76645-3570-46ff-a9a0-de13ae0bea67


## ⚠️ `axiosInstance` 에서 전역 interceptor 역할 변경
- 이전과 다르게 현재 변경된 `axiosInstance`는 전역 interceptor에서는 401 에러에 대해서 토큰 재발급 관련을 제외하고는 Error Status만을 리턴하고 있습니다. 일반 api 함수의 경우엔 각 api 함수에서 해당 Error 객체를 받아 에러 토스트 띄우기 등의 처리를 따로 진행해 주셔야 합니다.
- TanStack Query를 사용하는 통신의 경우엔 `useQueryErrorToast`, 혹은 `useMutationErrorToast` Hook에 Query 혹은 Mutation 객체를 넘겨줄 경우 해당 Error 객체를 받아 알아서 처리 해줄 겁니다.

## 💬리뷰 요구사항
- 현재 배포 직전의 상황에서 QA 사항들을 고치고 있는 중이라, `main` 브랜치에 바로 머지를 진행합니다. 바로 배포를 진행하기에, 제가 고친 부분들에서, 해당 변경 사항으로 인해 다른 팀원 분들의 작업 사항에 영향이 가는 부분이 없는지 확인 부탁드립니다!
- 401 등의 인증(Authorization) 이슈로 인해서 토큰 재발급 요청을 할 때, 이미 재발급을 진행할 땐 재발급을 하지 못하도록 flag 값을 추가하였습니다. 이에 대해서, 로직이 충분히 효율적인지 리뷰해 주시면 감사하겠습니다.
- TanStack Query와 관련된 객체 (Query, Mutation)의 에러 처리 및 에러 토스트를 띄우기 위해 각각 `useQueryErrorToast`, `useMutationErrorToast` Hook으로 분리하여 가져다 사용할 수 있는 구조로 구성했습니다. 해당 구조가 효율적으로 구성된 것인지 전체적으로 리뷰 부탁드립니다. 


## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
