### PR TITLE
Hotfix: 마이페이지 상세보기 카드 모바일 화면에 맞게 수정

### DIFF
--- a/src/components/profile/MovieCard.tsx
+++ b/src/components/profile/MovieCard.tsx
@@ -61,11 +61,11 @@ const MovieCard = ({
   }, [title]);
 
   const cardBaseClass =
-    'flex flex-col min-w-[300px] min-h-[540px] md:min-w-[400px] md:min-h-[680px] max-w-[400px] max-h-[680px] border-none rounded-2xl overflow-hidden';
+    'flex flex-col min-w-[280px] min-h-[440px] max-w-[400px] max-h-[680px] w-full h-full border-none rounded-2xl overflow-hidden';
 
   return (
     <Card className={cardBaseClass}>
-      <div className="relative w-full min-h-[180px] md:min-h-[220px]">
+      <div className="relative w-full h-[30%] min-h-[135px] md:min-h-[220px]">
         <Image
           src={imgSrc}
           alt={title}
@@ -76,112 +76,118 @@ const MovieCard = ({
           onError={() => setImgSrc('/images/default-backdrop.png')}
         />
       </div>
-      {!expanded && (
-        <CardHeader>
-          <div className="space-y-1 pb-2">
-            <h3 className="font-bold text-2xl leading-tight">{title}</h3>
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <span>{genres.join(', ')}</span>
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex items-center gap-2">
-              <h4 className="font-medium text-sm md:text-lg">플랫폼</h4>
-              <span className="text-xs text-muted-foreground">
-                (플랫폼 클릭 바로 보러가기)
-              </span>
+      <div className="overflow-y-auto">
+        {!expanded && (
+          <CardHeader>
+            <div className="space-y-1 pb-2">
+              <h3 className="font-bold text-xl md:text-2xl leading-tight">
+                {title}
+              </h3>
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <span>{genres.join(', ')}</span>
+              </div>
             </div>
 
-            <div className="flex flex-wrap gap-2">
-              {platforms.map((platform) => {
-                const imageSrc = getPlatformLogo(platform.platformType);
-                if (!imageSrc) return null;
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <h4 className="font-medium text-sm md:text-lg">플랫폼</h4>
+                <span className="text-xs text-muted-foreground">
+                  (플랫폼 클릭 바로 보러가기)
+                </span>
+              </div>
 
-                return (
-                  <CircleOption
-                    key={platform.platformType}
-                    label={platform.platformType}
-                    imageSrc={imageSrc}
-                    size="sm"
-                    onClick={() =>
-                      handlePlatformClick(
-                        platform.platformType,
-                        platform.watchUrl,
-                      )
-                    }
-                    showLabel={false}
-                  />
-                );
-              })}
-            </div>
-          </div>
-        </CardHeader>
-      )}
-      <CardContent className="relative flex flex-col space-y-3 py-2 flex-1">
-        {!expanded ? (
-          <>
-            {/* 일반 정보 */}
-            <div className="space-y-2 text-sm md:text-base">
-              <div className="flex items-center gap-2">
-                <span className="text-gray-60">감독</span>
-                <span className="ml-auto">{formatInfo(directors)}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-gray-60">개봉일</span>
-                <span className="ml-auto"> {formatDateInfo(openDate)}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-gray-60">러닝타임</span>
-                <span className="ml-auto">{formatInfo(runningTime)}</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-gray-60">연령 등급</span>
-                <span className="ml-auto">{formatInfo(rating)}</span>
-              </div>
-            </div>
-            {/* 줄거리 요약 */}
-            <div className="relative">
-              <h4 className="font-medium text-sm md:text-lg mb-2">줄거리</h4>
-              <p
-                ref={descRef}
-                className="text-sm md:text-base text-muted-foreground leading-relaxed line-clamp-2 md:line-clamp-3"
-              >
-                {description}
-              </p>
+              <div className="flex flex-wrap gap-2">
+                {platforms.map((platform) => {
+                  const imageSrc = getPlatformLogo(platform.platformType);
+                  if (!imageSrc) return null;
 
-              <div className="flex justify-end mt-1">
-                <button
-                  onClick={() => setExpanded(true)}
-                  className="text-xs md:text-sm text-primary-500 hover:underline"
-                >
-                  더보기 ▲
-                </button>
+                  return (
+                    <CircleOption
+                      key={platform.platformType}
+                      label={platform.platformType}
+                      imageSrc={imageSrc}
+                      size="sm"
+                      onClick={() =>
+                        handlePlatformClick(
+                          platform.platformType,
+                          platform.watchUrl,
+                        )
+                      }
+                      showLabel={false}
+                    />
+                  );
+                })}
               </div>
             </div>
-          </>
-        ) : (
-          <>
-            {/* 줄거리 전체 - 기존 정보 사라지고 이거만 */}
-            <div className="flex flex-col justify-between flex-1">
-              <div>
+          </CardHeader>
+        )}
+        <CardContent className="relative flex flex-col space-y-3 py-2 flex-1">
+          {!expanded ? (
+            <>
+              {/* 일반 정보 */}
+              <div className="space-y-2 text-sm md:text-base">
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-60">감독</span>
+                  <span className="ml-auto">{formatInfo(directors)}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-60">개봉일</span>
+                  <span className="ml-auto"> {formatDateInfo(openDate)}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-60">러닝타임</span>
+                  <span className="ml-auto">{formatInfo(runningTime)}</span>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-gray-60">연령 등급</span>
+                  <span className="ml-auto">{formatInfo(rating)}</span>
+                </div>
+              </div>
+              {/* 줄거리 요약 */}
+              <div className="relative">
                 <h4 className="font-medium text-sm md:text-lg mb-2">줄거리</h4>
-                <p className="text-sm md:text-base text-muted-foreground leading-relaxed whitespace-pre-wrap">
+                <p
+                  ref={descRef}
+                  className="text-sm md:text-base leading-relaxed line-clamp-2"
+                >
                   {description}
                 </p>
+
+                <div className="flex justify-end mt-1">
+                  <button
+                    onClick={() => setExpanded(true)}
+                    className="text-xs md:text-sm text-primary-500 hover:underline"
+                  >
+                    더보기 ▲
+                  </button>
+                </div>
               </div>
-              <div className="flex justify-end mt-4">
-                <button
-                  onClick={() => setExpanded(false)}
-                  className="text-xs md:text-sm text-primary-500 hover:underline"
-                >
-                  접기 ▼
-                </button>
+            </>
+          ) : (
+            <>
+              {/* 줄거리 전체 - 기존 정보 사라지고 이거만 */}
+              <div className="flex flex-col justify-between flex-1 px-2">
+                <div>
+                  <h4 className="font-medium text-sm md:text-lg mb-2">
+                    줄거리
+                  </h4>
+                  <p className="text-sm md:text-base leading-relaxed overflow-hidden">
+                    {description}
+                  </p>
+                </div>
+                <div className="flex justify-end mt-4">
+                  <button
+                    onClick={() => setExpanded(false)}
+                    className="text-xs md:text-sm text-primary-500 hover:underline"
+                  >
+                    접기 ▼
+                  </button>
+                </div>
               </div>
-            </div>
-          </>
-        )}
-      </CardContent>
+            </>
+          )}
+        </CardContent>
+      </div>
     </Card>
   );
 };

--- a/src/components/profile/MovieDetailModal.tsx
+++ b/src/components/profile/MovieDetailModal.tsx
@@ -3,6 +3,7 @@
 import { X } from 'lucide-react';
 import MovieCard from '@components/profile/MovieCard';
 import { StoredContentDetail } from '@type/profile/StoredContentDetail';
+import { useEffect, useRef } from 'react';
 
 interface MovieDetailModalProps {
   isOpen: boolean;
@@ -11,17 +12,29 @@ interface MovieDetailModalProps {
 }
 
 const MovieDetailModal = ({ isOpen, onClose, data }: MovieDetailModalProps) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  // 스크롤 막기
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/60 bg-opacity-50 flex justify-center items-center">
-      <div
-        className="relative bg-white rounded-xl 
-          w-[300px] min-h-[540px] 
-          md:w-[400px] md:min-h-[680px] 
-          max-w-[400px] max-h-[680px] 
-          overflow-y-auto"
-      >
+    <div
+      className="fixed inset-0 z-50 bg-black/60 bg-opacity-50 flex justify-center items-center"
+      role="dialog"
+      aria-modal="true"
+      tabIndex={-1}
+      ref={modalRef}
+    >
+      <div className="relative bg-white rounded-2xl h-[70svh] aspect-[75/135] min-w-70 min-h-110 max-w-100 max-h-180 md:w-[440px] md:h-[680px] overflow-hidden">
         <button
           onClick={onClose}
           className="absolute top-3 right-3 z-10 rounded-full bg-gray-500 p-1 hover:bg-gray-700"


### PR DESCRIPTION
## #️⃣연관된 이슈 (없으면 비워두세요) -> 어떤 이슈를 해결한 건지 연관되는 이슈 번호 작성

> ex) #이슈번호, #이슈번호

## 📝작업 내용

1. 모바일 화면에서 좋아요, 싫어요 컨텐트 상세보기 화면 안맞는 상황
   =>카드모드와 모달 전체적인 카드 크기 수정 
2. 모달이 띄어 졌을 때 위에 배경 스크롤 되지 않도록 수정

### 스크린샷 (선택)
<img width="405" height="674" alt="image" src="https://github.com/user-attachments/assets/7aa6b82a-974b-42cf-8e0b-e044db8bd24b" />


## 💬리뷰 요구사항(선택)

> Reviewer가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
