### PR TITLE
[UDT-191] 탐색(Explore) 페이지 QA 사항 2차 수정

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -59,9 +59,8 @@ export default function ExplorePage() {
       {/* 2. FilterRadioButtonGroup은 sticky가 아니라 그냥 여기에 둔다! */}
       <FilterRadioButtonGroup />
 
-      {/* 3. 나머지 모든 콘텐츠가 스크롤되는 영역 */}
-      <div className="flex-1 overflow-y-auto pb-15">
-        <div className="h-0" />
+      {/* 3. 나머지 모든 콘텐츠가 스크롤되는 영역 (여기에서만 overflow-y-auto 속성 사용) */}
+      <div className="flex-1 flex flex-col h-full overflow-y-auto pb-15">
         {filters !== undefined ? (
           <PosterCardsGrid
             contents={contents}

--- a/src/components/explore/ExplorePageCarousel.tsx
+++ b/src/components/explore/ExplorePageCarousel.tsx
@@ -64,22 +64,43 @@ export const ExplorePageCarousel = ({ autoPlayInterval = 3000 }) => {
   const getTargetX = (index: number) =>
     containerWidth / 2 - CARD_WIDTH / 2 - index * CARD_TOTAL_WIDTH;
 
+  // 자동 재생 조건 확인하는 값
+  const canAutoPlay = useMemo(() => {
+    return (
+      isDomReady &&
+      !isDragging &&
+      !jumping &&
+      currentIndex !== -1 &&
+      contentsLength > 0 &&
+      containerWidth > 0
+    );
+  }, [
+    isDomReady,
+    isDragging,
+    jumping,
+    currentIndex,
+    contentsLength,
+    containerWidth,
+  ]);
+
   // 1. 최초 마운트시 ref DOM이 완전히 준비된 뒤에만 width 계산
   useLayoutEffect(() => {
     let retryCount = 0;
+    let timeoutId: NodeJS.Timeout;
+
     function checkDomReady() {
       if (carouselRef.current) {
         setIsDomReady(true);
         setContainerWidth(carouselRef.current.offsetWidth);
       } else if (retryCount < 10) {
         retryCount += 1;
-        setTimeout(checkDomReady, 30); // ref 안 잡혔으면 조금 뒤에 재시도 (최대 10번)
+        timeoutId = setTimeout(checkDomReady, 30); // ref 안 잡혔으면 조금 뒤에 재시도 (최대 10번)
       }
     }
     checkDomReady();
-    // 컴포넌트 언마운트 후 setState 방지
+    // 컴포넌트 언마운트 후엔 pending된 setTimeout을 확실히 취소해야 함
     return () => {
-      retryCount = 10;
+      if (timeoutId) clearTimeout(timeoutId);
     };
   }, []);
 
@@ -162,15 +183,7 @@ export const ExplorePageCarousel = ({ autoPlayInterval = 3000 }) => {
 
   // 6. 자동 재생 (모든 조건 완전히 만족시에만)
   useEffect(() => {
-    if (
-      !isDomReady ||
-      isDragging ||
-      jumping ||
-      currentIndex === -1 ||
-      contentsLength === 0 ||
-      containerWidth === 0
-    )
-      return;
+    if (!canAutoPlay) return; // 자동 재생 조건 불만족시 종료
     const timer = setInterval(() => {
       setCurrentIndex((prev) => prev + 1);
     }, autoPlayInterval);

--- a/src/components/explore/FilterRadioButtonGroup.tsx
+++ b/src/components/explore/FilterRadioButtonGroup.tsx
@@ -103,7 +103,7 @@ export const FilterRadioButtonGroup = () => {
       >
         <div className="w-full">
           {/* 필터 버튼 그룹 */}
-          <div className="pt-5 pb-4">
+          <div className="pt-4 pb-4">
             <div
               ref={scrollRef}
               className="flex flex-row justify-start items-center gap-3 overflow-x-auto scrollbar-hide max-w-full overscroll-x-none px-6 select-none"

--- a/src/components/explore/FilterRadioButtonGroup.tsx
+++ b/src/components/explore/FilterRadioButtonGroup.tsx
@@ -13,18 +13,43 @@ import {
   useExploreUI,
   useExploreTempFilters,
 } from '@hooks/useExplorePageState';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 
 // FilterRadioButton을 모아두는 그룹 컴포넌트
 export const FilterRadioButtonGroup = () => {
   // 스크롤 위치 추적을 위한 state, Ref, 함수 정의
   const scrollRef = useRef<HTMLDivElement>(null);
+  const stickyRef = useRef<HTMLDivElement>(null);
+  const [isSticky, setIsSticky] = useState(false); // 현재 스크롤 위치에 따라 sticky 상태 감지
   const [isDragging, setIsDragging] = useState(false);
   const [dragMoved, setDragMoved] = useState(false);
   const dragStartX = useRef(0);
   const dragScrollLeft = useRef(0);
 
+  // sticky 상태를 감지하기 위해 사용하는 코드
+  useEffect(() => {
+    // sticky 바로 위에 삽입해서, 해당 element가 화면에 보이지 않으면 sticky 발동
+    const sentinel = document.createElement('div');
+    stickyRef.current?.parentNode?.insertBefore(sentinel, stickyRef.current);
+
+    const observer = new window.IntersectionObserver(
+      ([entry]) => {
+        setIsSticky(!entry.isIntersecting);
+      },
+      {
+        root: null, // window 기준으로 뷰포트 범위 내에서 확인
+        threshold: 0,
+      },
+    );
+    observer.observe(sentinel);
+    return () => {
+      observer.disconnect();
+      sentinel.remove();
+    };
+  }, []);
+
+  // 포인터 옵션 관련 핸들러
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     setIsDragging(true);
     setDragMoved(false);
@@ -47,6 +72,7 @@ export const FilterRadioButtonGroup = () => {
     (e.target as Element).releasePointerCapture?.(e.pointerId);
   };
 
+  // 필터 관련 상태 및 함수 추출 (Zustand를 사용한 상태 관리 훅에서 가져옴)
   const { appliedFilters, displayedOptionsInTop, toggleAppliedFilter } =
     useExploreFilters();
   const {
@@ -69,7 +95,12 @@ export const FilterRadioButtonGroup = () => {
 
   return (
     <>
-      <div className="w-full transition-colors duration-200 bg-transparent">
+      <div
+        ref={stickyRef}
+        className={`sticky top-0 z-10 w-full transition-colors duration-200 ${
+          isSticky ? 'bg-primary-800/80 backdrop-blur' : 'bg-transparent'
+        }`}
+      >
         <div className="w-full">
           {/* 필터 버튼 그룹 */}
           <div className="pt-5 pb-4">

--- a/src/components/explore/PosterCardsGrid.tsx
+++ b/src/components/explore/PosterCardsGrid.tsx
@@ -35,7 +35,6 @@ export const PosterCardsGrid = ({
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const handlePosterClick = (movieId: number) => {
-    //TODO: 이것을 네트워크 통신으로 대체해야 함
     setSelectedMovieId(movieId);
     setIsDetailBottomSheetOpen(true);
   };
@@ -61,7 +60,7 @@ export const PosterCardsGrid = ({
     <>
       {contents.length > 0 ? (
         <>
-          <div className="grid grid-cols-3 sm:grid-cols-4 gap-5 px-4 py-6 mx-auto transition-opacity duration-300">
+          <div className="grid grid-cols-3 sm:grid-cols-4 gap-5 px-4 py-6 mx-auto transition-opacity duration-300 justify-items-center">
             {contents.map((item, idx) => (
               <PosterCard
                 key={idx}
@@ -109,7 +108,7 @@ export const PosterCardsGrid = ({
         </>
       ) : (
         // 로딩 중인 것인지의 여부에 따라 나오는 텍스트가 달라야 함
-        <div className="w-full h-full flex items-center justify-center text-white">
+        <div className="flex flex-1 flex-col items-center justify-center text-white">
           {status === 'pending' ? '불러오는 중...' : '검색 결과가 없습니다.'}
         </div>
       )}


### PR DESCRIPTION
## #️⃣연관된 이슈
UDT-191

## 📝작업 내용
- `PosterCardsGrid`에서, Grid 칸 각각에 카드 정렬이 가운데 정렬 되는 것으로 수정
- `PosterCardsGrid`에서 상태 값(“불러오는 중…”, “검색 결과가 없습니다” 등)이 화면 가운데에 나오지 않는 문제 수정
- `ExplorePageCarousel`에서 잠재적으로 발생할 수 있는 오류에 대비하기 위한 코드 리팩토링
- `FilterRadioButtonGroup`에서 스크롤 시에 화면 상단에 고정 안되는 문제(`sticky` 옵션 적용 안되는 문제) 해결 및 스타일 수정

## 스크린샷
스크롤 시에 상단의 버튼이 제대로 sticky 되는 것, 그리고 `PosterCardGrid`의 정렬 및 스타일링 똑바로 돌아온 것을 확인할 수 있습니다.

https://github.com/user-attachments/assets/0c9f741f-7ffc-42da-ad40-03db170415bb

## 💬리뷰 요구사항
- `explore/page.tsx`에서 구성 되었던 레이아웃 형식을, 스크롤 불가능한 최상단 컴포넌트를 따로 하나 빼고, 그 안에서 스크롤 가능한 컨테이너를 또 하나 생성함으로써 `FilterRadioButtonGroup`에서 `sticky` 옵션이 먹히지 않는 문제를 해결했습니다. 해당 레이아웃 구성 방식이 효율적인지 리뷰 부탁드립니다!
- `ExplorePageCarousel`에서 CodeRabbit이 리뷰한 점을 반영해서 리팩토링을 진행했습니다. 해당 리팩토링이 효율적인 방향인지 리뷰 부탁드립니다!

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
