### PR TITLE
[UDT-208] 온보딩 query param 수정

### DIFF
--- a/src/app/layout-wrapper.tsx
+++ b/src/app/layout-wrapper.tsx
@@ -38,7 +38,13 @@ export default function LayoutWrapper({
       <div className="w-full min-h-[100svh] max-w-160 bg-gradient-to-b from-primary-900 via-purple-900 to-indigo-900 text-white flex flex-col relative pointer-events-auto">
         {/* 메인 콘텐츠 - 남은 공간 모두 사용 */}
         <main className="h-full flex flex-col overflow-y-auto">
-          <div className="h-[calc(100%-60px)]">{children}</div>
+          <div
+            style={{
+              height: shouldHideBottomNavbar ? '100%' : 'calc(100% - 60px)',
+            }}
+          >
+            {children}
+          </div>
           {!shouldHideBottomNavbar && <BottomNavbar />}
         </main>
       </div>

--- a/src/app/onboarding/OnboardingClient.tsx
+++ b/src/app/onboarding/OnboardingClient.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { StartScreen } from './onBordingStart';
+import Step0 from './Step0';
+import Step1 from './Step1';
+import Step2 from './Step2';
+import Step3 from './Step3';
+import Step4 from './Step4';
+import Step5 from './Step5';
+import Step6 from './Step6';
+import Step7 from './Step7';
+import Step8 from './Step8';
+import { usePageStayTracker } from '@hooks/usePageStayTracker';
+import { ProgressDots } from '@components/common/ProgressDots';
+
+export default function OnboardingPage() {
+  // 페이지 머무르는 시간 추적 (온보딩 페이지 추적 / Google Analytics 연동을 위함)
+  usePageStayTracker('onboarding');
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const stepParam = searchParams.get('step');
+  const step = useMemo(() => {
+    const parsed = parseInt(stepParam ?? '');
+    return isNaN(parsed) || parsed < 0 ? null : parsed;
+  }, [stepParam]);
+
+  const handleStepChange = (nextStep: number) => {
+    const newSearchParams = new URLSearchParams(searchParams);
+    newSearchParams.set('step', nextStep.toString());
+    router.push(`/onboarding?${newSearchParams.toString()}`);
+  };
+
+  const handleStart = () => handleStepChange(0);
+  const handleNext = () => {
+    if (step !== null && step < steps.length - 1) {
+      handleStepChange(step + 1);
+    }
+  };
+
+  const handleComplete = () => {
+    // isNewUser 쿠키 제거 (만료 시간을 과거로 설정)
+    document.cookie =
+      'X-New-User=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+    // 추천 페이지로 이동
+    router.push('/recommend');
+  };
+
+  if (step === null) return <StartScreen onStart={handleStart} />;
+
+  const steps = [
+    <Step0 onNext={handleNext} key={0} />, // Step0: 설명 + 카드
+    <Step1 onNext={handleNext} key={1} />, // Step1: 오른쪽 스와이프 설명
+    <Step2 onNext={handleNext} key={2} />, // Step2: 왼쪽 스와이프 설명
+    <Step3 onNext={handleNext} key={3} />, // Step3: 관심없음 설명
+    <Step4 onNext={handleNext} key={4} />, // Step4: 상세보기 카드 보여주기
+    <Step5 onNext={handleNext} key={5} />, // Step5: 실제 좋아요/싫어요 2회 시도 + 자동 전환
+    <Step6 onNext={handleNext} key={6} />, // Step6: 확인 토스트 반환
+    <Step7 onNext={handleNext} key={7} />, // Step7: 결과 창
+    <Step8 onNext={handleComplete} key={8} />, // Step8: 마이페이지 확인
+  ];
+
+  return (
+    <div className="relative w-full h-full flex flex-col items-center">
+      {/* 진행 바 상단에 고정 */}
+      <div className="w-full max-w-[640px] px-6 pt-6">
+        <ProgressDots currentStep={step} totalSteps={steps.length} />
+      </div>
+
+      {/* 현재 스텝 컴포넌트 */}
+      <div className="flex-1 w-full">{steps[step]}</div>
+    </div>
+  );
+}

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -3,7 +3,9 @@ import OnboardingClient from './OnboardingClient';
 
 export default function OnboardingPage() {
   return (
-    <Suspense fallback={<div>Loading...</div>}>
+    <Suspense
+      fallback={<div>데이터를 불러오고 있어요, 잠시만 기다려주세요.</div>}
+    >
       <OnboardingClient />
     </Suspense>
   );

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,77 +1,10 @@
-'use client';
-
-import { useMemo } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { StartScreen } from './onBordingStart';
-import Step0 from './Step0';
-import Step1 from './Step1';
-import Step2 from './Step2';
-import Step3 from './Step3';
-import Step4 from './Step4';
-import Step5 from './Step5';
-import Step6 from './Step6';
-import Step7 from './Step7';
-import Step8 from './Step8';
-import { usePageStayTracker } from '@hooks/usePageStayTracker';
-import { ProgressDots } from '@components/common/ProgressDots';
+import { Suspense } from 'react';
+import OnboardingClient from './OnboardingClient';
 
 export default function OnboardingPage() {
-  // 페이지 머무르는 시간 추적 (온보딩 페이지 추적 / Google Analytics 연동을 위함)
-  usePageStayTracker('onboarding');
-
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  const stepParam = searchParams.get('step');
-  const step = useMemo(() => {
-    const parsed = parseInt(stepParam ?? '');
-    return isNaN(parsed) || parsed < 0 ? null : parsed;
-  }, [stepParam]);
-
-  const handleStepChange = (nextStep: number) => {
-    const newSearchParams = new URLSearchParams(searchParams);
-    newSearchParams.set('step', nextStep.toString());
-    router.push(`/onboarding?${newSearchParams.toString()}`);
-  };
-
-  const handleStart = () => handleStepChange(0);
-  const handleNext = () => {
-    if (step !== null && step < steps.length - 1) {
-      handleStepChange(step + 1);
-    }
-  };
-
-  const handleComplete = () => {
-    // isNewUser 쿠키 제거 (만료 시간을 과거로 설정)
-    document.cookie =
-      'X-New-User=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
-    // 추천 페이지로 이동
-    router.push('/recommend');
-  };
-
-  if (step === null) return <StartScreen onStart={handleStart} />;
-
-  const steps = [
-    <Step0 onNext={handleNext} key={0} />, // Step0: 설명 + 카드
-    <Step1 onNext={handleNext} key={1} />, // Step1: 오른쪽 스와이프 설명
-    <Step2 onNext={handleNext} key={2} />, // Step2: 왼쪽 스와이프 설명
-    <Step3 onNext={handleNext} key={3} />, // Step3: 관심없음 설명
-    <Step4 onNext={handleNext} key={4} />, // Step4: 상세보기 카드 보여주기
-    <Step5 onNext={handleNext} key={5} />, // Step5: 실제 좋아요/싫어요 2회 시도 + 자동 전환
-    <Step6 onNext={handleNext} key={6} />, // Step6: 확인 토스트 반환
-    <Step7 onNext={handleNext} key={7} />, // Step7: 결과 창
-    <Step8 onNext={handleComplete} key={8} />, // Step8: 마이페이지 확인
-  ];
-
   return (
-    <div className="relative w-full h-full flex flex-col items-center">
-      {/* 진행 바 상단에 고정 */}
-      <div className="w-full max-w-[640px] px-6 pt-6">
-        <ProgressDots currentStep={step} totalSteps={steps.length} />
-      </div>
-
-      {/* 현재 스텝 컴포넌트 */}
-      <div className="flex-1 w-full">{steps[step]}</div>
-    </div>
+    <Suspense fallback={<div>Loading...</div>}>
+      <OnboardingClient />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
UDT-208

## 📝작업 내용
<h2>✅ 온보딩 스타일 변경</h2>
<p><strong>온보딩 단계 상태관리 useState → query param 방식으로 변경</strong></p>
<p>전체 레이아웃 nav바 없을 때 스타일 변경</strong></p>

<h2>✅ 주요 변경사항</h2>
<ul>
  <li>기존 <code>useState</code> 기반 <code>started</code>, <code>step</code> 상태 제거</li>
  <li>URL query string (<code>?step=0</code>, <code>?step=1</code> ...) 기반으로 단계 관리</li>
  <li><code>useSearchParams</code>, <code>router.push()</code>를 사용하여 단계 이동 제어</li>
  <li>뒤로가기 / 앞으로가기 시 이전 단계로 자연스럽게 이동 가능</li>
  <li>새로고침 시에도 현재 단계 유지</li>
  <li><code>StartScreen</code>은 <code>?step</code> query가 없을 때만 노출되도록 분기 처리</li>
  <li><code>ProgressDots</code> 및 각 Step 컴포넌트는 그대로 유지 (기존 <code>onNext</code> props 사용 방식 동일)</li>
 <li>전체 레이아웃 height: shouldHideBottomNavbar ? '100%' : 'calc(100% - 60px)'로 네비 없을 시 100%처리</li>
</ul>

<p>🔧 <code>useSearchParams</code> 클라이언트 훅 사용을 위해 <code>OnboardingClient</code> 컴포넌트를 <code>'use client'</code>로 분리하고, <code>page.tsx</code>에서 <code>&lt;Suspense&gt;</code>로 감싸도록 구조 리팩토링했습니다.</p>

## 💬리뷰 요구사항


## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
