### PR TITLE
[UDT-186] 피드백 삭제 엔드포인트 변경으로 인한 삭제 api 수정

### DIFF
--- a/src/app/profile/feedbacks/page.tsx
+++ b/src/app/profile/feedbacks/page.tsx
@@ -69,12 +69,11 @@ const FeedbackPage = () => {
   // 실제 삭제 api 연동 토스토 확인 시 삭제 되도록 구성
   const { mutateAsync: deleteFeedback } = useDeleteFeedback();
 
-  // 피드백 id의 경우 배열 처리로 수정하는데 시간이 걸린다 하여 우선 단일 처리 진행 후 수정
+  // 배열 삭제로 수정
   const { handleDelete } = useDeleteToast({
     selectedIds,
     onDeleteComplete: handleCancelDeleteMode,
-    deleteFn: deleteFeedback, // 단일 처리 함수
-    isBatch: false, // 명시적으로 단일 호출임을 지정
+    deleteFn: deleteFeedback,
   });
 
   //상세보기를 위한 모달 처리

--- a/src/app/profile/recommend/page.tsx
+++ b/src/app/profile/recommend/page.tsx
@@ -83,7 +83,6 @@ const RecommendPage = () => {
     selectedIds,
     onDeleteComplete: handleCancelDeleteMode,
     deleteFn: deleteCurated,
-    isBatch: true,
   });
 
   return (

--- a/src/hooks/profile/useDeleteFeedback.ts
+++ b/src/hooks/profile/useDeleteFeedback.ts
@@ -5,7 +5,7 @@ export const useDeleteFeedback = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (feedbackId: number) => deleteFeedback(feedbackId),
+    mutationFn: (feedbackId: number[]) => deleteFeedback(feedbackId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['feedbacks'] });
     },

--- a/src/hooks/profile/useDeleteToast.ts
+++ b/src/hooks/profile/useDeleteToast.ts
@@ -8,17 +8,13 @@ interface UseDeleteToastProps {
   selectedIds: number[];
   onDeleteComplete: () => void;
   // 현재 엄선된 삭제의 경우 배열 / 피드백의 경우 단일처리임(해당 부분의 경우 수정 될 예정) 이에 맞게 분기처리 후 나중에 수정
-  deleteFn:
-    | ((ids: number[]) => Promise<unknown>)
-    | ((id: number) => Promise<unknown>);
-  isBatch?: boolean; //배열인지 안닌지 확인
+  deleteFn: (ids: number[]) => Promise<unknown>;
 }
 
 export const useDeleteToast = ({
   selectedIds,
   onDeleteComplete,
   deleteFn,
-  isBatch = false,
 }: UseDeleteToastProps) => {
   const isToastOpen = useRef(false);
 
@@ -45,19 +41,7 @@ export const useDeleteToast = ({
       className: 'bg-white shadow-lg',
       onConfirm: async () => {
         try {
-          if (isBatch) {
-            //  배열 기반 API
-            await (deleteFn as (ids: number[]) => Promise<unknown>)(
-              selectedIds,
-            );
-          } else {
-            //  단일 기반 API (Promise.all)
-            await Promise.all(
-              selectedIds.map((id) =>
-                (deleteFn as (id: number) => Promise<unknown>)(id),
-              ),
-            );
-          }
+          await deleteFn(selectedIds);
 
           showSimpleToast.success({
             message: '삭제가 완료되었습니다.',

--- a/src/hooks/profile/useDeleteToast.ts
+++ b/src/hooks/profile/useDeleteToast.ts
@@ -7,7 +7,7 @@ import { useRef } from 'react';
 interface UseDeleteToastProps {
   selectedIds: number[];
   onDeleteComplete: () => void;
-  // 현재 엄선된 삭제의 경우 배열 / 피드백의 경우 단일처리임(해당 부분의 경우 수정 될 예정) 이에 맞게 분기처리 후 나중에 수정
+  // 현재 엄선된 삭제의 경우 배열
   deleteFn: (ids: number[]) => Promise<unknown>;
 }
 

--- a/src/lib/apis/profile/feedbackService.ts
+++ b/src/lib/apis/profile/feedbackService.ts
@@ -14,7 +14,9 @@ export const getFeedbackContents = async (
   return response.data;
 };
 
-//단일 삭제
-export const deleteFeedback = async (feedbackId: number): Promise<void> => {
-  await axiosInstance.delete(`/api/users/me/feedbacks/${feedbackId}`, {});
+//[DELETE] - 현재 api 이름 모름 임의 작성
+export const deleteFeedback = async (feedbackId: number[]): Promise<void> => {
+  await axiosInstance.delete(`/api/users/me/feedbacks/bulk`, {
+    data: { feedbackId },
+  });
 };

--- a/src/lib/apis/profile/feedbackService.ts
+++ b/src/lib/apis/profile/feedbackService.ts
@@ -15,8 +15,8 @@ export const getFeedbackContents = async (
 };
 
 //[DELETE] - 현재 api 이름 모름 임의 작성
-export const deleteFeedback = async (feedbackId: number[]): Promise<void> => {
-  await axiosInstance.delete(`/api/users/me/feedbacks/bulk`, {
-    data: { feedbackId },
+export const deleteFeedback = async (feedbackIds: number[]): Promise<void> => {
+  await axiosInstance.delete(`/api/users/me/feedbacks`, {
+    data: { feedbackIds },
   });
 };

--- a/src/lib/apis/profile/recommendService.ts
+++ b/src/lib/apis/profile/recommendService.ts
@@ -18,7 +18,6 @@ export const getCuratedContents = async (
 };
 
 //[DELETE] /api/api/users/me/curated/contents/bulk 리스트 형태로 삭제
-//현재 api 모름 임의로 작성
 export const deleteCuratedContents = async (
   contentIds: number[],
 ): Promise<void> => {


### PR DESCRIPTION
## #️⃣연관된 이슈
UDT-186

## 📝작업 내용

- 좋아요/싫어요 피드백 콘텐츠 배열 삭제 기능 구현
- DELETE API 경로를 `/api/users/me/feedbacks` 로 변경
- `axiosInstance.delete()`에 `{ data: { feedbackIds } }` 형식으로 데이터 전달
- `useDeleteFeedback` 훅 및 `useDeleteToast` 통합 처리
- `FeedbackPage`에서도 `RecommendPage`와 동일한 삭제 UI 흐름으로 통일

## 💬리뷰 요구사항(선택)

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
