### PR TITLE
[UDT-210] 관리자(백오피스) 페이지 최상단 page.tsx 수정 및 사이드 바, 요청 대기열 페이지 수정 + 일부 QA 사항 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@next/third-parties": "^15.4.3",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-radio-group": "^1.3.7",
         "@radix-ui/react-scroll-area": "^1.2.9",
@@ -3624,6 +3625,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.15.tgz",
+      "integrity": "sha512-mIBnOjgwo9AH3FyKaSWoSu/dYj6VdhJ7frEPiGTeXCdUFHjl9h3mFh2wwhEtINOmYXWhdpf1rY2minFsmaNgVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
@@ -3689,6 +3719,46 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.15.tgz",
+      "integrity": "sha512-tVlmA3Vb9n8SZSd+YSbuFR66l87Wiy4du+YE+0hzKQEANA+7cWKH1WgqcEX4pXqxUFQKrWQGHdvEfw00TjFiew==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@next/third-parties": "^15.4.3",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-scroll-area": "^1.2.9",

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,5 +1,69 @@
-import AdminDashboard from '@/components/admin/AdminDashboard';
+'use client';
 
-export default function Page() {
-  return <AdminDashboard />;
+import * as React from 'react';
+import AdminDashboard from '@components/admin/AdminDashboard';
+import { RequestQueueDashboard } from '@components/admin/RequestQueueDashboard';
+import { SmoothExpandableSidebar } from '@components/admin/SmoothExpandableSidebar';
+
+type TabType = 'request-queue' | 'content-management' | 'member-management';
+
+// 각 탭에 대한 정보를 포함하는 객체
+const tabConfig = {
+  'request-queue': {
+    title: '요청 대기열',
+    description: '사용자 요청을 확인하고 처리할 수 있습니다',
+    component: RequestQueueDashboard,
+  },
+  'content-management': {
+    title: '콘텐츠 관리',
+    description: '사이트의 콘텐츠를 생성, 수정, 삭제할 수 있습니다',
+    component: AdminDashboard,
+  },
+  'member-management': {
+    title: '회원 정보 관리',
+    description: '회원 정보를 조회하고 관리할 수 있습니다',
+    component: AdminDashboard,
+  },
+};
+
+// 관리 페이지의 최상단 컴포넌트
+export default function AdminPage() {
+  const [activeTab, setActiveTab] = React.useState<TabType>('request-queue');
+
+  const currentTab = tabConfig[activeTab]; // 현재 탭에 관한 정보 포함하는 객체
+  const CurrentComponent = currentTab.component; // 현재 탭에 관한 컴포넌트
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background transition-all duration-300 ease-out">
+      {/* 동적 헤더 */}
+      <header className="sticky top-0 z-30 flex h-16 items-center gap-4 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 px-6">
+        <div className="flex flex-col">
+          <h1 className="text-xl font-semibold text-foreground leading-tight">
+            {currentTab.title}
+          </h1>
+          <p className="text-sm text-muted-foreground leading-tight">
+            {currentTab.description}
+          </p>
+        </div>
+      </header>
+
+      {/* 메인 콘텐츠 영역 */}
+      <div className="relative flex-1">
+        {/* 전체 확장 사이드바 */}
+        <SmoothExpandableSidebar
+          activeTab={activeTab}
+          onTabChange={setActiveTab}
+        />
+        {/* 페이지 콘텐츠 */}
+        <main className="ml-16 p-6">
+          <div
+            key={activeTab}
+            className="animate-in fade-in-0 slide-in-from-right-4 duration-300"
+          >
+            <CurrentComponent />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
 }

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -56,7 +56,7 @@ export default function ExplorePage() {
         <span className="text-2xl font-semibold text-white">작품 탐색하기</span>
       </div>
 
-      {/* 2. FilterRadioButtonGroup은 sticky가 아니라 그냥 여기에 둔다! */}
+      {/* 2. FilterRadioButtonGroup의 sticky 옵션은 해당 컴포넌트 내부에 둔다! */}
       <FilterRadioButtonGroup />
 
       {/* 3. 나머지 모든 콘텐츠가 스크롤되는 영역 */}

--- a/src/components/admin/RequestQueueDashboard.tsx
+++ b/src/components/admin/RequestQueueDashboard.tsx
@@ -131,7 +131,7 @@ export function RequestQueueDashboard() {
                       <Button
                         size="sm"
                         variant="outline"
-                        className="rounded-full w-full h-full p-1 bg-red-600 opacity-80 text-white"
+                        className="rounded-full w-16 h-full p-1 bg-red-600 opacity-80 text-white"
                       >
                         취소
                       </Button>

--- a/src/components/admin/RequestQueueDashboard.tsx
+++ b/src/components/admin/RequestQueueDashboard.tsx
@@ -1,0 +1,148 @@
+import { Badge } from '@components/ui/badge';
+import { Button } from '@components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@components/ui/table';
+import { CirclePlus, FolderCheck, Pencil, Trash } from 'lucide-react';
+
+const mockRequests = [
+  {
+    logId: 1,
+    memberId: 10,
+    title: '집에 가고 싶다',
+    generateTime: '2025-07-31 10:15',
+    status: 'PENDING',
+  },
+  {
+    logId: 2,
+    memberId: 11,
+    title: '집에 가고 싶다22',
+    generateTime: '2025-08-01 10:15',
+    status: 'PENDING',
+  },
+  {
+    logId: 3,
+    memberId: 12,
+    title: '집에 가고 싶다33',
+    generateTime: '2025-08-02 10:15',
+    status: 'FAIL',
+  },
+];
+
+// 해당 요청의 종류를 표현하기 위한 색상 설정
+const requestTypeConfig = {
+  FAIL: { label: '실패', color: 'bg-red-100 text-red-800' },
+  PENDING: { label: '대기중', color: 'bg-orange-100 text-orange-800' },
+};
+
+// 배치 처리를 위해 pending 중인 요청 목록을 보여줌
+export function RequestQueueDashboard() {
+  return (
+    <div className="space-y-6">
+      {/* 상단의 카드 레이아웃(요청 대기열 관련 수치 정보 표시) */}
+      <div className="grid gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">전체</CardTitle>
+            <FolderCheck className="h-4 w-4 text-like" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold pb-2">24</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">콘텐츠 등록</CardTitle>
+            <CirclePlus className="h-4 w-4 text-success" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold pb-2">8</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">콘텐츠 수정</CardTitle>
+            <Pencil className="h-4 w-4 text-orange-800" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">5</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">콘텐츠 삭제</CardTitle>
+            <Trash className="h-4 w-4 text-destructive" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">11</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 요청 목록 테이블 */}
+      <Card className="py-4 px-2">
+        <CardHeader>
+          <CardTitle className="text-lg font-bold">요청 목록</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>요청 ID</TableHead>
+                <TableHead>제목</TableHead>
+                <TableHead>요청자 ID</TableHead>
+                <TableHead>생성 시간</TableHead>
+                <TableHead>상태</TableHead>
+                <TableHead>처리</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {mockRequests.map((request) => {
+                return (
+                  <TableRow key={request.logId}>
+                    <TableCell className="font-medium">
+                      {request.logId}
+                    </TableCell>
+                    <TableCell>{request.title}</TableCell>
+                    <TableCell>{request.memberId}</TableCell>
+                    <TableCell>{request.generateTime}</TableCell>
+                    <TableCell>
+                      <Badge
+                        className={`${
+                          requestTypeConfig[
+                            request.status as keyof typeof requestTypeConfig
+                          ].color
+                        }`}
+                      >
+                        {
+                          requestTypeConfig[
+                            request.status as keyof typeof requestTypeConfig
+                          ].label
+                        }
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="rounded-full w-full h-full p-1 bg-red-600 opacity-80 text-white"
+                      >
+                        취소
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/admin/RequestQueueDashboard.tsx
+++ b/src/components/admin/RequestQueueDashboard.tsx
@@ -10,6 +10,14 @@ import {
   TableRow,
 } from '@components/ui/table';
 import { CirclePlus, FolderCheck, Pencil, Trash } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@components/ui/dropdown-menu';
+import { Filter, ChevronDown } from 'lucide-react';
+import { useState } from 'react';
 
 const mockRequests = [
   {
@@ -43,6 +51,9 @@ const requestTypeConfig = {
 
 // 배치 처리를 위해 pending 중인 요청 목록을 보여줌
 export function RequestQueueDashboard() {
+  const [selectedFilter, setSelectedFilter] = useState<string>('전체');
+  const filterOptions = ['전체', '콘텐츠 등록', '콘텐츠 수정', '콘텐츠 삭제']; // 필터링 옵션들
+
   return (
     <div className="space-y-6">
       {/* 상단의 카드 레이아웃(요청 대기열 관련 수치 정보 표시) */}
@@ -71,7 +82,7 @@ export function RequestQueueDashboard() {
             <Pencil className="h-4 w-4 text-orange-800" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">5</div>
+            <div className="text-2xl font-bold pb-2">5</div>
           </CardContent>
         </Card>
         <Card>
@@ -80,7 +91,7 @@ export function RequestQueueDashboard() {
             <Trash className="h-4 w-4 text-destructive" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">11</div>
+            <div className="text-2xl font-bold pb-2">11</div>
           </CardContent>
         </Card>
       </div>
@@ -88,7 +99,31 @@ export function RequestQueueDashboard() {
       {/* 요청 목록 테이블 */}
       <Card className="py-4 px-2">
         <CardHeader>
-          <CardTitle className="text-lg font-bold">요청 목록</CardTitle>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg font-bold">요청 목록</CardTitle>
+
+            {/* 필터 드롭다운 */}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="gap-2 bg-transparent">
+                  <Filter className="h-4 w-4" />
+                  {selectedFilter}
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                {filterOptions.map((option) => (
+                  <DropdownMenuItem
+                    key={option}
+                    onClick={() => setSelectedFilter(option)}
+                    className={selectedFilter === option ? 'bg-accent' : ''}
+                  >
+                    {option}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </CardHeader>
         <CardContent>
           <Table>
@@ -130,8 +165,7 @@ export function RequestQueueDashboard() {
                     <TableCell>
                       <Button
                         size="sm"
-                        variant="outline"
-                        className="rounded-full w-16 h-full p-1 bg-red-600 opacity-80 text-white"
+                        className="rounded-full w-16 h-full p-1 bg-red-600 opacity-80 text-white cursor-pointer"
                       >
                         취소
                       </Button>

--- a/src/components/admin/SmoothExpandableSidebar.tsx
+++ b/src/components/admin/SmoothExpandableSidebar.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import * as React from 'react';
+import { Clock, FileText, Users } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type TabType = 'request-queue' | 'content-management' | 'member-management';
+
+interface SmoothExpandableSidebarProps {
+  activeTab: TabType;
+  onTabChange: (tab: TabType) => void;
+}
+
+const menuItems = [
+  {
+    id: 'request-queue' as TabType, // 요청 대기열
+    title: '요청 대기열',
+    icon: Clock,
+  },
+  {
+    id: 'content-management' as TabType, // 콘텐츠 관리
+    title: '콘텐츠 관리',
+    icon: FileText,
+  },
+  {
+    id: 'member-management' as TabType, // 회원 정보 관리
+    title: '회원 정보 관리',
+    icon: Users,
+  },
+];
+
+// 자연스럽게 x축 방향으로 확장되는 사이드바
+export function SmoothExpandableSidebar({
+  activeTab,
+  onTabChange,
+}: SmoothExpandableSidebarProps) {
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  // 마우스 올려놨을 때 확장
+  const handleMouseEnter = () => {
+    setIsExpanded(true);
+  };
+
+  // 마우스 떠나면 축소
+  const handleMouseLeave = () => {
+    setIsExpanded(false);
+  };
+
+  return (
+    <div
+      className={cn(
+        'fixed left-0 top-16 z-40 h-full bg-sidebar border-r border-sidebar-border flex flex-col',
+        'transition-all duration-300 ease-out shadow-lg',
+        isExpanded ? 'w-64' : 'w-16',
+      )}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      {/* 메뉴 영역 */}
+      <nav className="flex-1 py-2">
+        {menuItems.map((item, index) => (
+          <button
+            key={item.id}
+            onClick={() => onTabChange(item.id)}
+            className={cn(
+              'w-full h-12 flex items-center transition-all duration-200',
+              'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+              'px-4 group relative',
+              activeTab === item.id &&
+                'bg-sidebar-accent text-sidebar-accent-foreground',
+            )}
+            style={{
+              transitionDelay: isExpanded ? `${index * 50}ms` : '0ms',
+            }}
+          >
+            {/* 아이콘 */}
+            <div className="flex-shrink-0 flex items-center justify-center w-8">
+              <item.icon className="size-5" />
+            </div>
+
+            {/* 텍스트 - 확장 시에만 표시 */}
+            <div
+              className={cn(
+                'ml-3 transition-all duration-300 ease-out whitespace-nowrap',
+                isExpanded
+                  ? 'opacity-100 translate-x-0'
+                  : 'opacity-0 -translate-x-4',
+              )}
+              style={{
+                transitionDelay: isExpanded ? `${100 + index * 30}ms` : '0ms',
+              }}
+            >
+              <span className="text-sm font-medium">{item.title}</span>
+            </div>
+
+            {/* 활성 상태 표시 바 (선택 된 거 표시) */}
+            {activeTab === item.id && (
+              <div className="absolute right-0 top-2 bottom-2 w-1 bg-sidebar-primary rounded-l-full" />
+            )}
+          </button>
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/explore/ExplorePageCarousel.tsx
+++ b/src/components/explore/ExplorePageCarousel.tsx
@@ -151,8 +151,8 @@ export const ExplorePageCarousel = ({ autoPlayInterval = 3000 }) => {
   const handleDragEnd = useCallback(
     (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
       let next = currentIndex;
-      if (info.offset.x < -SWIPE_THRESHOLD || info.velocity.x < -400) next += 1;
-      else if (info.offset.x > SWIPE_THRESHOLD || info.velocity.x > 400)
+      if (info.offset.x < -SWIPE_THRESHOLD || info.velocity.x < -50) next += 1;
+      else if (info.offset.x > SWIPE_THRESHOLD || info.velocity.x > 50)
         next -= 1;
       setIsDragging(false);
       setCurrentIndex(next);
@@ -282,7 +282,7 @@ export const ExplorePageCarousel = ({ autoPlayInterval = 3000 }) => {
         <SheetContent
           side="bottom"
           hideDefaultClose={true}
-          className="px-0 pb-5 h-[90svh] max-w-[640px] w-full mx-auto rounded-t-2xl bg-primary-800 flex flex-col overflow-y-auto scrollbar-hide gap-0"
+          className="px-0 pb-5 h-[90svh] max-w-[640px] w-full mx-auto rounded-t-2xl bg-primary-800 flex flex-col overflow-y-auto scrollbar-hide gap-0 !border-none"
         >
           <button
             onClick={() => setSelectedContent(null)}

--- a/src/components/explore/FilterRadioButtonGroup.tsx
+++ b/src/components/explore/FilterRadioButtonGroup.tsx
@@ -108,7 +108,7 @@ export const FilterRadioButtonGroup = () => {
                 {/* Sheet 콘텐츠 (해당 콘텐츠는 FilterBottomSheetContent 컴포넌트로 구현) */}
                 <SheetContent
                   side="bottom"
-                  className="flex flex-col gap-0 h-[60svh] max-h-[60svh] max-w-[640px] w-full mx-auto bg-[#07033E] border-t-0 rounded-t-[20px]"
+                  className="flex flex-col gap-0 h-[60svh] max-h-[60svh] max-w-[640px] w-full mx-auto bg-[#07033E] border-t-0 rounded-t-[20px] !border-none"
                 >
                   {/* 커스텀 닫기 버튼 */}
                   <button

--- a/src/components/explore/PosterCardScrollBox.tsx
+++ b/src/components/explore/PosterCardScrollBox.tsx
@@ -154,7 +154,7 @@ export const PosterCardScrollBox = ({
         <SheetContent
           side="bottom"
           hideDefaultClose={true} // 기본 닫기 버튼 제거
-          className="px-0 pb-5 h-[90svh] max-w-[640px] w-full mx-auto rounded-t-2xl bg-primary-800 flex flex-col overflow-y-auto scrollbar-hide gap-0"
+          className="px-0 pb-5 h-[90svh] max-w-[640px] w-full mx-auto rounded-t-2xl bg-primary-800 flex flex-col overflow-y-auto scrollbar-hide gap-0 !border-none"
         >
           {/* 커스텀 X 버튼 (z-index로 위에 배치) */}
           <button

--- a/src/components/explore/PosterCardsGrid.tsx
+++ b/src/components/explore/PosterCardsGrid.tsx
@@ -82,7 +82,7 @@ export const PosterCardsGrid = ({
               <SheetContent
                 side="bottom"
                 hideDefaultClose={true} // 기본 닫기 버튼 제거
-                className="px-0 pb-5 h-[90svh] max-w-[640px] w-full mx-auto rounded-t-2xl bg-primary-800 flex flex-col overflow-y-auto scrollbar-hide gap-0"
+                className="px-0 pb-5 h-[90svh] max-w-[640px] w-full mx-auto rounded-t-2xl bg-primary-800 flex flex-col overflow-y-auto scrollbar-hide gap-0 !border-none"
               >
                 {/* 커스텀 X 버튼 (z-index로 위에 배치) */}
                 <button

--- a/src/components/explore/PosterCardsGrid.tsx
+++ b/src/components/explore/PosterCardsGrid.tsx
@@ -61,7 +61,7 @@ export const PosterCardsGrid = ({
     <>
       {contents.length > 0 ? (
         <>
-          <div className="grid grid-cols-3 sm:grid-cols-4 gap-5 px-4 py-6 mx-auto transition-opacity duration-300">
+          <div className="grid grid-cols-3 sm:grid-cols-4 gap-5 px-4 py-6 mx-auto transition-opacity duration-300 justify-items-center">
             {contents.map((item, idx) => (
               <PosterCard
                 key={idx}

--- a/src/components/explore/RepresentativeContentCard.tsx
+++ b/src/components/explore/RepresentativeContentCard.tsx
@@ -24,7 +24,7 @@ export const RepresentativeContentCard = memo(
     );
 
     return (
-      <Card className="flex flex-col w-68 h-87 overflow-hidden group cursor-pointer transition-transform duration-200 border-none">
+      <Card className="!border-none !bg-transparent !shadow-none flex flex-col w-68 h-87 overflow-hidden group cursor-pointer transition-transform duration-200">
         <div className="relative flex-grow">
           <Image
             src={posterImgSrc}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import * as React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { CheckIcon, ChevronRightIcon, CircleIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  );
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  inset?: boolean;
+  variant?: 'default' | 'destructive';
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:!text-destructive [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[inset]:pl-8 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        'px-2 py-1.5 text-sm font-medium data-[inset]:pl-8',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('bg-border -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        'text-muted-foreground ml-auto text-xs tracking-widest',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        'focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[inset]:pl-8',
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+};

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn('w-full caption-bottom text-sm', className)}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn('[&_tr]:border-b', className)}
+      {...props}
+    />
+  );
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn('[&_tr:last-child]:border-0', className)}
+      {...props}
+    />
+  );
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        'bg-muted/50 border-t font-medium [&>tr]:last:border-b-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<'caption'>) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn('text-muted-foreground mt-4 text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};


### PR DESCRIPTION
## #️⃣연관된 이슈
UDT-210

## 📝작업 내용
- 관리자(`/admin`) 페이지의 최상단 컴포넌트(`page.tsx`)에 다른 페이지를 오갈 수 있는 `SmoothExpandableSidebar` 추가
- 서버에서의 콘텐츠 수정/삭제/등록 요청들에 대해 배치 처리로 인해 pending 중인 요청 목록을 조회 및 취소할 수 있는 `RequestQueueDashboard` 추가 (현재 수정 중)
- `DetailBottomSheetContent` 등의 컴포넌트에 대해 일부 화면에서 표시될 때 흰색 테두리가 보이는 문제 해결 (해당하는 `Sheet`, `Card` 컴포넌트에 `!border-none`, `!shadow-none` 등의 옵션 추가)

## 스크린샷
`admin`의 최상단 페이지에 `SmoothExpandableSidebar`를 두고, 동적 헤더, 그리고 사이드바 콘텐츠 선택에 따른 자식 컴포넌트를 갈아 끼는 방식으로 구성되어 있습니다. 데스크톱 기준이며, 아래는 해당 컴포넌트 구현 실제 시연 영상입니다.

https://github.com/user-attachments/assets/f376ff52-a1ce-495f-9c41-a9011d0209e3


## 💬리뷰 요구사항
- `admin` 페이지의 `page.tsx` 구조를 사이드바 구성과 동적 헤더 구성으로 인해 많이 변경되었습니다. 데스크톱 기준으로 구성되어 있으며, 어드민 페이지의 최상단 `page.tsx`가 효율적으로 구성되어 있는지 리뷰 부탁드립니다.
- `ChildrenComponent`를 맵핑한 다음, 해당하는 컴포넌트를 불러오는 방식으로 구성되어 있습니다. 해당 구조가 효율적인지 리뷰 부탁드립니다. MockData는 나중에 api 연동 후엔 지울 예정입니다!

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
