### PR TITLE
[UDT-230] 콘텐츠 무한스크롤 자연스럽게 개선 및 삭제모드 UX 향상

### DIFF
--- a/src/app/profile/recommend/page.tsx
+++ b/src/app/profile/recommend/page.tsx
@@ -11,7 +11,7 @@ import MovieDetailModal from '@components/profile/MovieDetailModal';
 import { useDeleteMode } from '@hooks/profile/useDeleteMode';
 import { useDeleteCurated } from '@hooks/profile/useDeleteCurated';
 import { usePageStayTracker } from '@hooks/usePageStayTracker';
-import { useDeleteToast } from '@/hooks/profile/useDeleteToast';
+import { useDeleteToast } from '@hooks/profile/useDeleteToast';
 
 const RecommendPage = () => {
   // 페이지 머무르는 시간 추적 (저장된 엄선된 콘텐츠 조회하는 페이지 추적 / Google Analytics 연동을 위함)
@@ -26,7 +26,7 @@ const RecommendPage = () => {
   } = usePosterModal();
 
   // 무한스크롤 API 호출
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
     useInfiniteCuratedContents({ size: 20 });
 
   const posters = useMemo(
@@ -52,6 +52,8 @@ const RecommendPage = () => {
     }
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, isEmpty]);
+
+  const triggerIndex = Math.max(posters.length - 8, 0);
 
   // 상세보기 데이터 contentid로 찾아서 데이터 보여줌
   const selectedContentId = selectedPosterData?.contentId ?? null;
@@ -126,17 +128,28 @@ const RecommendPage = () => {
         </div>
       </div>
 
+      {/* 라인 */}
+      <div className="w-full max-w-screen-md mb-4 border-b border-white/30" />
+
       {/* 카드 영역 */}
-      <div className="w-full max-w-screen-md">
-        {isEmpty ? (
-          <div className="flex flex-col items-center justify-center h-full text-gray-400 text-sm font-medium">
+      <div className="elative w-full max-w-screen-md min-h-[70Svh]">
+        {isLoading ? (
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+              <p className="text-white">데이터를 불러오는 중...</p>
+            </div>
+          </div>
+        ) : isEmpty ? (
+          <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-white md:text-m  text-sm font-medium">
             현재 저장된 추천 콘텐츠가 없습니다
           </div>
         ) : (
           <div className="grid grid-cols-2 md:grid-cols-3 gap-x-6 gap-y-8 justify-items-center">
-            {posters.map((poster) => (
+            {posters.map((poster, index) => (
               <PosterCard
                 key={poster.contentId}
+                ref={index === triggerIndex ? observerRef : null}
                 title={poster.title}
                 image={poster.posterUrl}
                 size="lg"
@@ -145,7 +158,6 @@ const RecommendPage = () => {
                 onClick={() => handleCardClick(poster)}
               />
             ))}
-            <div ref={observerRef} className="h-1 w-full" />
           </div>
         )}
       </div>

--- a/src/app/profile/recommend/page.tsx
+++ b/src/app/profile/recommend/page.tsx
@@ -132,7 +132,7 @@ const RecommendPage = () => {
       <div className="w-full max-w-screen-md mb-4 border-b border-white/30" />
 
       {/* 카드 영역 */}
-      <div className="elative w-full max-w-screen-md min-h-[70Svh]">
+      <div className="relative w-full max-w-screen-md min-h-[70Svh]">
         {isLoading ? (
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center">
             <div className="text-center">

--- a/src/components/explore/PosterCard.tsx
+++ b/src/components/explore/PosterCard.tsx
@@ -1,6 +1,6 @@
 import { checkImgSrcValidity } from '@utils/checkImgSrcValidity';
 import Image from 'next/image';
-import { useCallback, useMemo, useState } from 'react';
+import { forwardRef, Ref, useCallback, useMemo, useState } from 'react';
 
 interface PosterCardProps {
   title: string | undefined;
@@ -13,112 +13,120 @@ interface PosterCardProps {
 }
 
 // 포스터 카드 컴포넌트 (누르면 상세페이지로 이동)
-export const PosterCard = ({
-  title,
-  image,
-  isTitleVisible = true,
-  onClick,
-  size = 'sm',
-  isDeletable = false,
-  isSelected = false,
-}: PosterCardProps) => {
-  const [hasError, setHasError] = useState(false); // 이미지 로딩 오류 여부 상태 관리
-  const [hasLoaded, setHasLoaded] = useState(false);
+export const PosterCard = forwardRef<HTMLDivElement, PosterCardProps>(
+  (
+    {
+      title,
+      image,
+      isTitleVisible = true,
+      onClick,
+      size = 'sm',
+      isDeletable = false,
+      isSelected = false,
+    },
+    ref: Ref<HTMLDivElement>,
+  ) => {
+    const [hasError, setHasError] = useState(false); // 이미지 로딩 오류 여부 상태 관리
+    const [hasLoaded, setHasLoaded] = useState(false);
 
-  // 드래그(누름) 시 기본 동작 막기
-  const handlePointerDown = (e: React.PointerEvent) => {
-    e.preventDefault(); // 기본 클릭/포커스/이미지 드래그 방지!
-  };
+    // 드래그(누름) 시 기본 동작 막기
+    const handlePointerDown = (e: React.PointerEvent) => {
+      e.preventDefault(); // 기본 클릭/포커스/이미지 드래그 방지!
+    };
 
-  // 사이즈별 width/height 설정
-  const dimensions =
-    size === 'lg' ? { width: 160, height: 220 } : { width: 110, height: 154 };
+    // 사이즈별 width/height 설정
+    const dimensions =
+      size === 'lg' ? { width: 160, height: 220 } : { width: 110, height: 154 };
 
-  const titleClass =
-    size === 'lg' ? 'text-base max-w-[160px]' : 'text-sm max-w-[120px]';
+    const titleClass =
+      size === 'lg' ? 'text-base max-w-[160px]' : 'text-sm max-w-[120px]';
 
-  // 이미지가 유효한 지 렌더 타임에 검증하는 메소드 validSrc
-  const validSrc = useMemo(() => {
-    if (hasError) {
-      // 에러가 있다면
-      return '/images/default-poster.png';
-    }
+    // 이미지가 유효한 지 렌더 타임에 검증하는 메소드 validSrc
+    const validSrc = useMemo(() => {
+      if (hasError) {
+        // 에러가 있다면
+        return '/images/default-poster.png';
+      }
 
-    if (checkImgSrcValidity(image)) {
-      // 이미지 경로를 검증했을 때, 유효한지 여부 탐색
-      return image;
-    } else {
-      return '/images/default-poster.png';
-    }
-  }, [image, hasError]);
+      if (checkImgSrcValidity(image)) {
+        // 이미지 경로를 검증했을 때, 유효한지 여부 탐색
+        return image;
+      } else {
+        return '/images/default-poster.png';
+      }
+    }, [image, hasError]);
 
-  // onError 핸들러 (한 번만 호출돼도 hasError=true)
-  const handleError = useCallback(() => {
-    setHasError(true);
-  }, []);
+    // onError 핸들러 (한 번만 호출돼도 hasError=true)
+    const handleError = useCallback(() => {
+      setHasError(true);
+    }, []);
 
-  // 로드가 다 되었는지 확인하는 handleLoadComplete
-  const handleLoadComplete = useCallback(() => setHasLoaded(true), []);
+    // 로드가 다 되었는지 확인하는 handleLoadComplete
+    const handleLoadComplete = useCallback(() => setHasLoaded(true), []);
 
-  return (
-    <div
-      onClick={onClick}
-      onPointerDown={handlePointerDown}
-      className="relative cursor-pointer flex flex-col items-center"
-      style={{
-        width: `${dimensions.width}px`,
-        minWidth: `${dimensions.width}px`,
-        maxWidth: `${dimensions.width}px`,
-      }}
-    >
-      {/* 이미지 로딩 전: 스켈레톤 */}
-      {!hasLoaded && (
-        <div
-          className={`inset-0 bg-gray-100 animate-pulse rounded-lg transition-opacity duration-500 ease-in-out ${
-            hasLoaded ? 'opacity-0' : 'opacity-100'
-          }`}
+    return (
+      <div
+        ref={ref}
+        onClick={onClick}
+        onPointerDown={handlePointerDown}
+        className="relative cursor-pointer flex flex-col items-center"
+        style={{
+          width: `${dimensions.width}px`,
+          minWidth: `${dimensions.width}px`,
+          maxWidth: `${dimensions.width}px`,
+        }}
+      >
+        {/* 이미지 로딩 전: 스켈레톤 */}
+        {!hasLoaded && (
+          <div
+            className={`inset-0 bg-gray-100 animate-pulse rounded-lg transition-opacity duration-500 ease-in-out ${
+              hasLoaded ? 'opacity-0' : 'opacity-100'
+            }`}
+            style={{
+              width: `${dimensions.width}px`,
+              height: `${dimensions.height}px`,
+              backgroundColor: '#a4a9b0', // Tailwind의 bg-gray-300
+            }}
+          />
+        )}
+
+        {/* 포스터 이미지 (오류 나면 default-poster.png 로 대체)*/}
+        <Image
+          src={validSrc}
+          alt={title || '포스터'}
+          width={dimensions.width}
+          height={dimensions.height}
+          onError={handleError}
+          onLoadingComplete={handleLoadComplete}
+          unoptimized
           style={{
+            position: hasLoaded ? 'static' : 'absolute',
             width: `${dimensions.width}px`,
             height: `${dimensions.height}px`,
-            backgroundColor: '#a4a9b0', // Tailwind의 bg-gray-300
           }}
+          className={`object-cover rounded-lg transition-opacity duration-500 ease-in-out delay-100 ${
+            isDeletable && isSelected ? 'opacity-60' : 'opacity-100'
+          }`}
         />
-      )}
+        {/* 삭제 모드 체크 아이콘 */}
+        {isDeletable && (
+          <div className="absolute top-1 right-1 w-5 h-5 bg-white rounded-full flex items-center justify-center z-10">
+            {isSelected && (
+              <span className="text-xs text-black font-bold">✔</span>
+            )}
+          </div>
+        )}
 
-      {/* 포스터 이미지 (오류 나면 default-poster.png 로 대체)*/}
-      <Image
-        src={validSrc}
-        alt={title || '포스터'}
-        width={dimensions.width}
-        height={dimensions.height}
-        onError={handleError}
-        onLoadingComplete={handleLoadComplete}
-        unoptimized
-        style={{
-          position: hasLoaded ? 'static' : 'absolute',
-          width: `${dimensions.width}px`,
-          height: `${dimensions.height}px`,
-        }}
-        className={`object-cover rounded-lg transition-opacity duration-500 ease-in-out delay-100 ${
-          isDeletable && isSelected ? 'opacity-60' : 'opacity-100'
-        }`}
-      />
-      {/* 삭제 모드 체크 아이콘 */}
-      {isDeletable && (
-        <div className="absolute top-1 right-1 w-5 h-5 bg-white rounded-full flex items-center justify-center z-10">
-          {isSelected && (
-            <span className="text-xs text-black font-bold">✔</span>
-          )}
-        </div>
-      )}
+        {isTitleVisible && ( // 포스터 카드 title(제목) 표시 여부 제한 사이즈별 분기
+          <span
+            className={`${titleClass} text-white font-normal mt-2 truncate block`}
+          >
+            {title}
+          </span>
+        )}
+      </div>
+    );
+  },
+);
 
-      {isTitleVisible && ( // 포스터 카드 title(제목) 표시 여부 제한 사이즈별 분기
-        <span
-          className={`${titleClass} text-white font-normal mt-2 truncate block`}
-        >
-          {title}
-        </span>
-      )}
-    </div>
-  );
-};
+PosterCard.displayName = 'PosterCard';

--- a/src/components/explore/PosterCardsGrid.tsx
+++ b/src/components/explore/PosterCardsGrid.tsx
@@ -56,6 +56,8 @@ export const PosterCardsGrid = ({
     };
   }, [loadMoreRef.current, hasNextPage, isFetchingNextPage]);
 
+  const triggerIndex = Math.max(contents.length - 8, 0); // 앞에서 8번째 카드에 ref
+
   return (
     <>
       {contents.length > 0 ? (
@@ -64,14 +66,12 @@ export const PosterCardsGrid = ({
             {contents.map((item, idx) => (
               <PosterCard
                 key={idx}
+                ref={idx === triggerIndex ? loadMoreRef : null}
                 title={item.title}
                 image={item.posterUrl}
                 onClick={() => handlePosterClick(item.contentId)}
               />
             ))}
-
-            {/* 무한스크롤 트리거용 빈 div */}
-            <div ref={loadMoreRef} className="col-span-3 h-1" />
 
             {/* 영화 상세 정보 BottomSheet (필요 시 pop-up) */}
             <Sheet


### PR DESCRIPTION
## #️⃣연관된 이슈 (없으면 비워두세요) -> 어떤 이슈를 해결한 건지 연관되는 이슈 번호 작성

>Udt 230

## 📝작업 내용

1. **PosterCard 컴포넌트에 `ref` 바인딩 가능하도록 수정**
   - `forwardRef` 및 `displayName` 지정하여 외부에서 관찰 가능한 요소로 활용 가능하도록 처리
   - 무한스크롤 트리거를 카드 자체에 걸 수 있게 되어 UX가 더 자연스러워짐

2. **무한스크롤 동작 방식 개선**
   - 기존에는 `div` 요소에만 `ref`를 걸어 리스트 마지막에서 API 요청을 트리거함
   - → 자연스럽지 못하고 스크롤이 멈춘 뒤에야 새 데이터가 로드되는 UX 문제가 있었음
   - **수정 후**: 마지막에서 8번째 카드(`triggerIndex`)에 `ref`를 걸어 IntersectionObserver가 더 일찍 작동되도록 개선
   - → 사용자가 리스트를 스크롤하면서 *끊김 없이 콘텐츠가 이어지도록* UX 향상

3. **적용된 페이지**
   - `/explore`: ExplorePage → `PosterCardsGrid`에 `ref` 위치 변경
   - `/profile/feedback`: FeedbackPage → `PosterCard`에 `ref` 적용
   - `/profile/recommend`: RecommendPage → 동일한 방식으로 개선
   - 각 페이지마다 공통적으로 `Math.max(contents.length - 8, 0)` 로 트리거 카드 지정

4. **삭제모드 UX 개선**
   - 삭제모드 상태에서 탭 전환 시, `useEffect`로 `handleCancelDeleteMode()` 자동 호출되도록 처리
   - 사용자 실수로 인한 혼란 방지

5. **로딩 중인 상태에 대한 시각적 안내 개선**
   - 콘텐츠가 없을 때, 로딩 중일 때 모두 화면 중앙에 메시지/스피너 노출되도록 UI 개선
   - 사용자에게 명확한 상태 전달 가능


### 스크린샷 (선택)

1. 무한스크롤 문제 사항(버벅 거리는 듯한 로딩)

https://github.com/user-attachments/assets/1b893c70-b841-400c-a3d9-a9eeb68f7bbe

1-1 수정후

https://github.com/user-attachments/assets/7388dc17-db2f-4ab5-8844-3b35341e82bd

2. 로딩 중 잠깐 컨텐츠 없을 때 컨텐츠가 없습니다 뜸 // 로딩 추가

https://github.com/user-attachments/assets/8dc583e2-2493-493c-9d3b-daa49c0b9c23

3. 삭제모드 탭 전환시에도 살아있음 없앰

https://github.com/user-attachments/assets/8b13221b-cf26-4aed-a4ff-c537c26f6914


## 💬리뷰 요구사항(선택)

> @gichulLimitLess  준호씨 탐색페이지 및 포스터 카드 수정 사항 확인 주세요~

## ✅ 체크리스트

- [ ] 코드가 정상적으로 동작함
- [ ] UI/UX가 일관됨
- [ ] 관련 테스트가 추가됨
- [ ] 이슈에 연결되었음 (ex. Close #123)
