### PR TITLE
[UDT-229] 관리자 페이지 콘텐츠 관리 중 인물 등록 탭 구현

### DIFF
--- a/src/components/admin/ContentDetail.tsx
+++ b/src/components/admin/ContentDetail.tsx
@@ -116,7 +116,7 @@ export default function ContentDetail({
                             <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
                               <Image
                                 src={director.directorImageUrl}
-                                alt={director.directorName || '출연진 이미지'}
+                                alt={director.directorName || '감독 이미지'}
                                 fill
                                 unoptimized
                                 className="object-cover"

--- a/src/components/admin/ContentDetail.tsx
+++ b/src/components/admin/ContentDetail.tsx
@@ -112,21 +112,15 @@ export default function ContentDetail({
                           key={director.directorId}
                           className="flex items-center gap-3 p-3 border rounded-lg"
                         >
-                          {director.directorImageUrl ? (
-                            <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
-                              <Image
-                                src={director.directorImageUrl}
-                                alt={director.directorName || '감독 이미지'}
-                                fill
-                                unoptimized
-                                className="object-cover"
-                              />
-                            </div>
-                          ) : (
-                            <div className="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center">
-                              <Users className="h-6 w-6 text-gray-400" />
-                            </div>
-                          )}
+                          <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
+                            <Image
+                              src={director.directorImageUrl}
+                              alt={director.directorName || '감독 이미지'}
+                              fill
+                              unoptimized
+                              className="object-cover"
+                            />
+                          </div>
                           <div>
                             <div className="font-medium">
                               {director.directorName}
@@ -192,21 +186,15 @@ export default function ContentDetail({
                         key={cast.castId}
                         className="flex items-center gap-3 p-3 border rounded-lg"
                       >
-                        {cast.castImageUrl ? (
-                          <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
-                            <Image
-                              src={cast.castImageUrl}
-                              alt={cast.castName || '출연진 이미지'}
-                              fill
-                              unoptimized
-                              className="object-cover"
-                            />
-                          </div>
-                        ) : (
-                          <div className="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center">
-                            <Users className="h-6 w-6 text-gray-400" />
-                          </div>
-                        )}
+                        <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
+                          <Image
+                            src={cast.castImageUrl}
+                            alt={cast.castName || '출연진 이미지'}
+                            fill
+                            unoptimized
+                            className="object-cover"
+                          />
+                        </div>
                         <div>
                           <div className="font-medium">{cast.castName}</div>
                         </div>

--- a/src/components/admin/ContentForm.tsx
+++ b/src/components/admin/ContentForm.tsx
@@ -5,35 +5,25 @@ import type React from 'react';
 import { useCallback, useState } from 'react';
 
 import { Button } from '@components/ui/button';
-import { Input } from '@components/ui/input';
-import { Label } from '@components/ui/label';
-import { Textarea } from '@components/ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@components/ui/select';
-import { Badge } from '@components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@components/ui/tabs';
-import { X, Plus, Upload, Image as ImageIcon } from 'lucide-react';
 import type {
   ContentWithoutId,
   ContentCreateUpdate,
   PlatformInfo,
 } from '@type/admin/Content';
-import { PLATFORMS } from '@lib/platforms';
 import { showSimpleToast } from '@components/common/Toast';
 import { useErrorToastOnce } from '@hooks/useErrorToastOnce';
 import { usePostUploadImages } from '@hooks/admin/usePostUploadImages';
-import { RATING_OPTIONS, CONTENT_CATEGORIES, COUNTRIES } from '@/constants';
-import { getGenresByCategory } from '@lib/genres';
-import Image from 'next/image';
 import ActorSearchDialog from '@components/admin/dialogs/actorSearchDialog';
 import DirectorSearchDialog from '@components/admin/dialogs/directorSearchDialog';
 import BulkPersonRegistration from './bulkPersonRegistration';
+
+// 분리된 컴포넌트들 import
+import BasicInfo from '@components/admin/ContentFormSections/BasicInfo';
+import DetailedInfo from '@components/admin/ContentFormSections/DetailedInfo';
+import DirectorInfo from '@components/admin/ContentFormSections/DirectorInfo';
+import CastInfo from '@components/admin/ContentFormSections/CastInfo';
+import PlatformSection from '@components/admin/ContentFormSections/PlatformInfo';
 
 interface ContentFormProps {
   content?: ContentWithoutId;
@@ -152,8 +142,8 @@ export default function ContentForm({
           [imageType === 'poster' ? 'posterUrl' : 'backdropUrl']: uploadedUrl,
         }));
       }
-    } catch (error) {
-      console.error('이미지 업로드 실패:', error);
+    } catch {
+      showSimpleToast.error({ message: '이미지 업로드에 실패했습니다.' });
     }
   };
 
@@ -317,537 +307,45 @@ export default function ContentForm({
 
         <TabsContent value="contentInfo" className="space-y-6 mt-3">
           {/* 기본 정보 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="mt-5">기본 정보</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="title" className="mb-3">
-                    제목 *
-                  </Label>
-                  <Input
-                    id="title"
-                    value={formData.title}
-                    onChange={(e) =>
-                      updateFormData((prev) => ({
-                        ...prev,
-                        title: e.target.value,
-                      }))
-                    }
-                    required
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="rating" className="mb-3">
-                    관람등급 *
-                  </Label>
-                  <Select
-                    value={formData.rating}
-                    onValueChange={(value) =>
-                      updateFormData((prev) => ({ ...prev, rating: value }))
-                    }
-                  >
-                    <SelectTrigger className="cursor-pointer">
-                      {formData.rating ? (
-                        <span>{formData.rating}</span>
-                      ) : (
-                        <SelectValue placeholder="관람등급 선택" />
-                      )}
-                    </SelectTrigger>
-                    <SelectContent>
-                      {RATING_OPTIONS.map((rating) => (
-                        <SelectItem
-                          key={rating}
-                          value={rating}
-                          className="cursor-pointer"
-                        >
-                          {rating}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                </div>
-              </div>
-
-              <div>
-                <Label htmlFor="description" className="mb-3">
-                  줄거리
-                </Label>
-                <Textarea
-                  id="description"
-                  value={formData.description}
-                  onChange={(e) =>
-                    updateFormData((prev) => ({
-                      ...prev,
-                      description: e.target.value,
-                    }))
-                  }
-                  rows={4}
-                />
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <Label htmlFor="posterUpload" className="mb-3">
-                    포스터 이미지
-                  </Label>
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() =>
-                          document.getElementById('posterUpload')?.click()
-                        }
-                        disabled={uploadImagesMutation.isPending}
-                        className="flex items-center gap-2"
-                      >
-                        <Upload className="h-4 w-4" />
-                        {uploadImagesMutation.isPending
-                          ? '업로드 중...'
-                          : '이미지 선택'}
-                      </Button>
-                      {formData.posterUrl && (
-                        <div className="flex items-center gap-2">
-                          <ImageIcon className="h-4 w-4 text-green-500" />
-                          <span className="text-sm text-green-600">
-                            업로드 완료
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                    <input
-                      id="posterUpload"
-                      type="file"
-                      accept="image/*"
-                      onChange={(e) =>
-                        handleImageUpload(e.target.files, 'poster')
-                      }
-                      className="hidden"
-                    />
-                    {formData.posterUrl && (
-                      <div className="relative w-20 h-28 border rounded overflow-hidden">
-                        <Image
-                          src={formData.posterUrl}
-                          alt="포스터 미리보기"
-                          fill
-                          unoptimized
-                          className="object-cover"
-                        />
-                      </div>
-                    )}
-                  </div>
-                </div>
-                <div>
-                  <Label htmlFor="backdropUpload" className="mb-3">
-                    배경 이미지
-                  </Label>
-                  <div className="space-y-2">
-                    <div className="flex items-center gap-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        onClick={() =>
-                          document.getElementById('backdropUpload')?.click()
-                        }
-                        disabled={uploadImagesMutation.isPending}
-                        className="flex items-center gap-2"
-                      >
-                        <Upload className="h-4 w-4" />
-                        {uploadImagesMutation.isPending
-                          ? '업로드 중...'
-                          : '이미지 선택'}
-                      </Button>
-                      {formData.backdropUrl && (
-                        <div className="flex items-center gap-2">
-                          <ImageIcon className="h-4 w-4 text-green-500" />
-                          <span className="text-sm text-green-600">
-                            업로드 완료
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                    <input
-                      id="backdropUpload"
-                      type="file"
-                      accept="image/*"
-                      onChange={(e) =>
-                        handleImageUpload(e.target.files, 'backdrop')
-                      }
-                      className="hidden"
-                    />
-                    {formData.backdropUrl && (
-                      <div className="relative w-32 h-20 border rounded overflow-hidden">
-                        <Image
-                          src={formData.backdropUrl}
-                          alt="배경 이미지 미리보기"
-                          fill
-                          unoptimized
-                          className="object-cover"
-                        />
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              <div>
-                <Label htmlFor="trailerUrl" className="mb-3">
-                  예고편 URL
-                </Label>
-                <Input
-                  id="trailerUrl"
-                  value={formData.trailerUrl}
-                  onChange={(e) =>
-                    updateFormData((prev) => ({
-                      ...prev,
-                      trailerUrl: e.target.value,
-                    }))
-                  }
-                  className="mb-5"
-                />
-              </div>
-            </CardContent>
-          </Card>
+          <BasicInfo
+            formData={formData}
+            updateFormData={updateFormData}
+            handleImageUpload={handleImageUpload}
+            uploadImagesMutation={uploadImagesMutation}
+          />
 
           {/* 상세 정보 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="mt-5">상세 정보</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="grid grid-cols-3 gap-4">
-                <div>
-                  <Label htmlFor="openDate" className="mb-3">
-                    개봉일
-                  </Label>
-                  <Input
-                    id="openDate"
-                    type="date"
-                    value={formData.openDate?.split('T')[0] || ''}
-                    onChange={(e) =>
-                      updateFormData((prev) => ({
-                        ...prev,
-                        openDate: e.target.value,
-                      }))
-                    }
-                    className="dark:bg-gray-700 dark:text-black"
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="runningTime" className="mb-3">
-                    상영시간 (분)
-                  </Label>
-                  <Input
-                    id="runningTime"
-                    type="number"
-                    min="0"
-                    value={formData.runningTime}
-                    onChange={(e) =>
-                      updateFormData((prev) => ({
-                        ...prev,
-                        runningTime: Number(e.target.value) || 0,
-                      }))
-                    }
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="episode" className="mb-3">
-                    에피소드
-                  </Label>
-                  <Input
-                    id="episode"
-                    type="number"
-                    min="0"
-                    value={formData.episode}
-                    onChange={(e) =>
-                      updateFormData((prev) => ({
-                        ...prev,
-                        episode: Number(e.target.value) || 0,
-                      }))
-                    }
-                  />
-                </div>
-              </div>
-
-              <div>
-                <Label htmlFor="category" className="mb-3">
-                  카테고리 *
-                </Label>
-                <Select
-                  value={formData.categories[0]?.categoryType || ''}
-                  onValueChange={(value) => {
-                    updateFormData((prev) => {
-                      const updatedCategories = [...prev.categories];
-
-                      if (updatedCategories[0]) {
-                        updatedCategories[0].categoryType = value;
-                        updatedCategories[0].genres = [];
-                      } else {
-                        updatedCategories[0] = {
-                          categoryType: value,
-                          genres: [],
-                        };
-                      }
-                      return { ...prev, categories: updatedCategories };
-                    });
-                  }}
-                >
-                  <SelectTrigger className="cursor-pointer">
-                    <SelectValue placeholder="카테고리 선택" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CONTENT_CATEGORIES.map((category) => (
-                      <SelectItem
-                        key={category}
-                        value={category}
-                        className="cursor-pointer"
-                      >
-                        {category}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {formData.categories[0]?.categoryType && (
-                <div>
-                  <Label className="mb-3">장르 *</Label>
-                  <div className="flex flex-wrap gap-2 max-w-full">
-                    {(() => {
-                      const selectedCategory =
-                        formData.categories[0]?.categoryType || '';
-                      const availableGenres =
-                        getGenresByCategory(selectedCategory);
-
-                      return availableGenres.map((genre) => {
-                        const isSelected =
-                          formData.categories[0]?.genres.includes(genre);
-
-                        return (
-                          <Badge
-                            key={genre}
-                            variant={isSelected ? 'default' : 'secondary'}
-                            className={`cursor-pointer select-none ${
-                              isSelected ? 'bg-blue-600 text-white' : ''
-                            }`}
-                            onClick={() =>
-                              isSelected ? removeGenre(genre) : addGenre(genre)
-                            }
-                          >
-                            {genre}
-                          </Badge>
-                        );
-                      });
-                    })()}
-                  </div>
-                </div>
-              )}
-
-              <div>
-                <Label className="mb-3">제작 국가</Label>
-                <div className="flex flex-wrap gap-2 mb-5 ">
-                  {COUNTRIES.map((country) => {
-                    const isSelected = formData.countries.includes(country);
-
-                    return (
-                      <Badge
-                        key={country}
-                        variant={isSelected ? 'default' : 'secondary'}
-                        className={`cursor-pointer select-none ${
-                          isSelected ? 'bg-green-600 text-white' : ''
-                        }`}
-                        onClick={() =>
-                          isSelected
-                            ? removeCountry(country)
-                            : addCountry(country)
-                        }
-                      >
-                        {country}
-                      </Badge>
-                    );
-                  })}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <DetailedInfo
+            formData={formData}
+            updateFormData={updateFormData}
+            addGenre={addGenre}
+            removeGenre={removeGenre}
+            addCountry={addCountry}
+            removeCountry={removeCountry}
+          />
 
           {/* 감독 정보 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="mt-5">감독 정보</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <Button
-                type="button"
-                onClick={() => setIsDirectorSearchOpen(true)}
-                className="w-full"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                감독 검색 및 추가
-              </Button>
-              <div className="space-y-2 mb-5">
-                {formData.directors.map((director) => (
-                  <div
-                    key={director.directorId}
-                    className="flex items-center justify-between p-2 border rounded"
-                  >
-                    <div className="flex items-center gap-2">
-                      {director.directorImageUrl && (
-                        <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
-                          <Image
-                            src={
-                              director.directorImageUrl || '/placeholder.svg'
-                            }
-                            alt={director.directorName || '감독 이미지'}
-                            fill
-                            unoptimized
-                            className="w-8 h-8 rounded-full object-cover"
-                          />
-                        </div>
-                      )}
-                      <span>{director.directorName}</span>
-                    </div>
-                    <Button
-                      type="button"
-                      className="cursor-pointer"
-                      size="sm"
-                      onClick={() => removeDirector(director.directorName)}
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+          <DirectorInfo
+            formData={formData}
+            setIsDirectorSearchOpen={setIsDirectorSearchOpen}
+            removeDirector={removeDirector}
+          />
 
           {/* 출연진 정보 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="mt-5">출연진 정보</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <Button
-                type="button"
-                onClick={() => setIsActorSearchOpen(true)}
-                className="w-full"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                출연진 검색 및 추가
-              </Button>
-              <div className="space-y-2 mb-5">
-                {formData.casts.map((cast) => (
-                  <div
-                    key={cast.castId}
-                    className="flex items-center justify-between p-2 border rounded"
-                  >
-                    <div className="flex items-center gap-2">
-                      {cast.castImageUrl && (
-                        <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
-                          <Image
-                            src={cast.castImageUrl || '/placeholder.svg'}
-                            alt={cast.castName || '출연진 이미지'}
-                            fill
-                            unoptimized
-                            className="w-8 h-8 rounded-full object-cover"
-                          />
-                        </div>
-                      )}
-                      <span>{cast.castName}</span>
-                    </div>
-                    <Button
-                      type="button"
-                      className="cursor-pointer"
-                      size="sm"
-                      onClick={() => removeCast(cast.castName)}
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+          <CastInfo
+            formData={formData}
+            setIsActorSearchOpen={setIsActorSearchOpen}
+            removeCast={removeCast}
+          />
 
           {/* 시청 플랫폼 */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="mt-5">시청 플랫폼 *</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4 mb-5">
-              <div className="grid grid-cols-2 gap-2 mb-2">
-                <Select
-                  value={newPlatform.platformType}
-                  onValueChange={(value) =>
-                    setNewPlatform({
-                      ...newPlatform,
-                      platformType: value,
-                    })
-                  }
-                >
-                  <SelectTrigger className="cursor-pointer">
-                    <SelectValue placeholder="플랫폼 선택" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {PLATFORMS.map((platform) => (
-                      <SelectItem
-                        key={platform.id}
-                        value={platform.label}
-                        className="cursor-pointer"
-                      >
-                        {platform.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Input
-                  value={newPlatform.watchUrl}
-                  onChange={(e) =>
-                    setNewPlatform({ ...newPlatform, watchUrl: e.target.value })
-                  }
-                  placeholder="시청 URL"
-                />
-              </div>
-              <div className="flex items-center space-x-2 mb-3"></div>
-              <Button
-                type="button"
-                onClick={addPlatform}
-                className="w-full mb-10 cursor-pointer"
-              >
-                <Plus className="h-4 w-4 mr-2" />
-                플랫폼 추가
-              </Button>
-              <div className="space-y-2">
-                {formData.platforms.map((platform, index) => (
-                  <div
-                    key={index}
-                    className="flex items-center justify-between p-2 border rounded"
-                  >
-                    <div>
-                      <div className="font-medium">{platform.platformType}</div>
-                      <div className="text-sm text-gray-500">
-                        {platform.watchUrl}
-                      </div>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      className="cursor-pointer"
-                      size="sm"
-                      onClick={() => removePlatform(index)}
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            </CardContent>
-          </Card>
+          <PlatformSection
+            formData={formData}
+            newPlatform={newPlatform}
+            setNewPlatform={setNewPlatform}
+            addPlatform={addPlatform}
+            removePlatform={removePlatform}
+          />
 
           {/* 배우 검색 다이얼로그 */}
           <ActorSearchDialog

--- a/src/components/admin/ContentForm.tsx
+++ b/src/components/admin/ContentForm.tsx
@@ -874,26 +874,27 @@ export default function ContentForm({
             }}
             existingDirectors={formData.directors}
           />
+
+          {/* 취소/수정 버튼 */}
+          <div className="flex justify-end space-x-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onCancel}
+              className="cursor-pointer"
+            >
+              취소
+            </Button>
+            <Button type="submit" className="cursor-pointer">
+              {content ? '수정' : '추가'}
+            </Button>
+          </div>
         </TabsContent>
 
         <TabsContent value="personRegistration" className="space-y-6 mt-3">
           <BulkPersonRegistration />
         </TabsContent>
       </Tabs>
-
-      <div className="flex justify-end space-x-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={onCancel}
-          className="cursor-pointer"
-        >
-          취소
-        </Button>
-        <Button type="submit" className="cursor-pointer">
-          {content ? '수정' : '추가'}
-        </Button>
-      </div>
     </form>
   );
 }

--- a/src/components/admin/ContentForm.tsx
+++ b/src/components/admin/ContentForm.tsx
@@ -16,7 +16,6 @@ import { useErrorToastOnce } from '@hooks/useErrorToastOnce';
 import { usePostUploadImages } from '@hooks/admin/usePostUploadImages';
 import ActorSearchDialog from '@components/admin/dialogs/actorSearchDialog';
 import DirectorSearchDialog from '@components/admin/dialogs/directorSearchDialog';
-import BulkPersonRegistration from './bulkPersonRegistration';
 
 // 분리된 컴포넌트들 import
 import BasicInfo from '@components/admin/ContentFormSections/BasicInfo';
@@ -24,6 +23,7 @@ import DetailedInfo from '@components/admin/ContentFormSections/DetailedInfo';
 import DirectorInfo from '@components/admin/ContentFormSections/DirectorInfo';
 import CastInfo from '@components/admin/ContentFormSections/CastInfo';
 import PlatformSection from '@components/admin/ContentFormSections/PlatformInfo';
+import BulkPersonRegistration from '@components/admin/bulkPersonRegistration';
 
 interface ContentFormProps {
   content?: ContentWithoutId;
@@ -240,11 +240,11 @@ export default function ContentForm({
   );
 
   const removeDirector = useCallback(
-    (directorToRemove: string) => {
+    (directorIdToRemove: number) => {
       updateFormData((prev) => ({
         ...prev,
         directors: prev.directors.filter(
-          (d) => d.directorName !== directorToRemove,
+          (d) => d.directorId !== directorIdToRemove,
         ),
       }));
     },
@@ -252,10 +252,10 @@ export default function ContentForm({
   );
 
   const removeCast = useCallback(
-    (castToRemove: string) => {
+    (castIdToRemove: number) => {
       updateFormData((prev) => ({
         ...prev,
-        casts: prev.casts.filter((c) => c.castName !== castToRemove),
+        casts: prev.casts.filter((c) => c.castId !== castIdToRemove),
       }));
     },
     [updateFormData],

--- a/src/components/admin/ContentForm.tsx
+++ b/src/components/admin/ContentForm.tsx
@@ -33,6 +33,7 @@ import { getGenresByCategory } from '@lib/genres';
 import Image from 'next/image';
 import ActorSearchDialog from '@components/admin/dialogs/actorSearchDialog';
 import DirectorSearchDialog from '@components/admin/dialogs/directorSearchDialog';
+import BulkPersonRegistration from './bulkPersonRegistration';
 
 interface ContentFormProps {
   content?: ContentWithoutId;
@@ -309,7 +310,7 @@ export default function ContentForm({
           <TabsTrigger value="contentInfo" className="cursor-pointer">
             콘텐츠 등록
           </TabsTrigger>
-          <TabsTrigger value="platforms" className="cursor-pointer">
+          <TabsTrigger value="personRegistration" className="cursor-pointer">
             인물 등록
           </TabsTrigger>
         </TabsList>
@@ -875,7 +876,9 @@ export default function ContentForm({
           />
         </TabsContent>
 
-        <TabsContent value="platforms" className="space-y-6 mt-3"></TabsContent>
+        <TabsContent value="personRegistration" className="space-y-6 mt-3">
+          <BulkPersonRegistration />
+        </TabsContent>
       </Tabs>
 
       <div className="flex justify-end space-x-2">

--- a/src/components/admin/ContentFormSections/BasicInfo.tsx
+++ b/src/components/admin/ContentFormSections/BasicInfo.tsx
@@ -17,6 +17,7 @@ import { RATING_OPTIONS } from '@/constants';
 import Image from 'next/image';
 import type { ContentWithoutId } from '@type/admin/Content';
 import type { UseMutationResult } from '@tanstack/react-query';
+import { useRef } from 'react';
 
 interface BasicInfoProps {
   formData: ContentWithoutId;
@@ -41,6 +42,9 @@ export default function BasicInfo({
   handleImageUpload,
   uploadImagesMutation,
 }: BasicInfoProps) {
+  const posterInputRef = useRef<HTMLInputElement>(null);
+  const backdropInputRef = useRef<HTMLInputElement>(null);
+
   return (
     <Card>
       <CardHeader>
@@ -124,9 +128,7 @@ export default function BasicInfo({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() =>
-                    document.getElementById('posterUpload')?.click()
-                  }
+                  onClick={() => posterInputRef.current?.click()}
                   disabled={uploadImagesMutation.isPending}
                   className="flex items-center gap-2"
                 >
@@ -143,7 +145,7 @@ export default function BasicInfo({
                 )}
               </div>
               <input
-                id="posterUpload"
+                ref={posterInputRef}
                 type="file"
                 accept="image/*"
                 onChange={(e) => handleImageUpload(e.target.files, 'poster')}
@@ -172,9 +174,7 @@ export default function BasicInfo({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() =>
-                    document.getElementById('backdropUpload')?.click()
-                  }
+                  onClick={() => backdropInputRef.current?.click()}
                   disabled={uploadImagesMutation.isPending}
                   className="flex items-center gap-2"
                 >
@@ -191,7 +191,7 @@ export default function BasicInfo({
                 )}
               </div>
               <input
-                id="backdropUpload"
+                ref={backdropInputRef}
                 type="file"
                 accept="image/*"
                 onChange={(e) => handleImageUpload(e.target.files, 'backdrop')}

--- a/src/components/admin/ContentFormSections/BasicInfo.tsx
+++ b/src/components/admin/ContentFormSections/BasicInfo.tsx
@@ -79,11 +79,7 @@ export default function BasicInfo({
               }
             >
               <SelectTrigger className="cursor-pointer">
-                {formData.rating ? (
-                  <span>{formData.rating}</span>
-                ) : (
-                  <SelectValue placeholder="관람등급 선택" />
-                )}
+                <SelectValue placeholder="관람등급 선택" />
               </SelectTrigger>
               <SelectContent>
                 {RATING_OPTIONS.map((rating) => (

--- a/src/components/admin/ContentFormSections/BasicInfo.tsx
+++ b/src/components/admin/ContentFormSections/BasicInfo.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { Button } from '@components/ui/button';
+import { Input } from '@components/ui/input';
+import { Label } from '@components/ui/label';
+import { Textarea } from '@components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/ui/select';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
+import { Upload, Image as ImageIcon } from 'lucide-react';
+import { RATING_OPTIONS } from '@/constants';
+import Image from 'next/image';
+import type { ContentWithoutId } from '@type/admin/Content';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+interface BasicInfoProps {
+  formData: ContentWithoutId;
+  updateFormData: (
+    updater: (prev: ContentWithoutId) => ContentWithoutId,
+  ) => void;
+  handleImageUpload: (
+    files: FileList | null,
+    imageType: 'poster' | 'backdrop',
+  ) => Promise<void>;
+  uploadImagesMutation: UseMutationResult<
+    { data: { uploadedFileUrls: string[] } },
+    Error,
+    File[],
+    unknown
+  >;
+}
+
+export default function BasicInfo({
+  formData,
+  updateFormData,
+  handleImageUpload,
+  uploadImagesMutation,
+}: BasicInfoProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="mt-5">기본 정보</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="title" className="mb-3">
+              제목 *
+            </Label>
+            <Input
+              id="title"
+              value={formData.title}
+              onChange={(e) =>
+                updateFormData((prev) => ({
+                  ...prev,
+                  title: e.target.value,
+                }))
+              }
+              required
+            />
+          </div>
+          <div>
+            <Label htmlFor="rating" className="mb-3">
+              관람등급 *
+            </Label>
+            <Select
+              value={formData.rating}
+              onValueChange={(value) =>
+                updateFormData((prev) => ({ ...prev, rating: value }))
+              }
+            >
+              <SelectTrigger className="cursor-pointer">
+                {formData.rating ? (
+                  <span>{formData.rating}</span>
+                ) : (
+                  <SelectValue placeholder="관람등급 선택" />
+                )}
+              </SelectTrigger>
+              <SelectContent>
+                {RATING_OPTIONS.map((rating) => (
+                  <SelectItem
+                    key={rating}
+                    value={rating}
+                    className="cursor-pointer"
+                  >
+                    {rating}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div>
+          <Label htmlFor="description" className="mb-3">
+            줄거리
+          </Label>
+          <Textarea
+            id="description"
+            value={formData.description}
+            onChange={(e) =>
+              updateFormData((prev) => ({
+                ...prev,
+                description: e.target.value,
+              }))
+            }
+            rows={4}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <Label htmlFor="posterUpload" className="mb-3">
+              포스터 이미지
+            </Label>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    document.getElementById('posterUpload')?.click()
+                  }
+                  disabled={uploadImagesMutation.isPending}
+                  className="flex items-center gap-2"
+                >
+                  <Upload className="h-4 w-4" />
+                  {uploadImagesMutation.isPending
+                    ? '업로드 중...'
+                    : '이미지 선택'}
+                </Button>
+                {formData.posterUrl && (
+                  <div className="flex items-center gap-2">
+                    <ImageIcon className="h-4 w-4 text-green-500" />
+                    <span className="text-sm text-green-600">업로드 완료</span>
+                  </div>
+                )}
+              </div>
+              <input
+                id="posterUpload"
+                type="file"
+                accept="image/*"
+                onChange={(e) => handleImageUpload(e.target.files, 'poster')}
+                className="hidden"
+              />
+              {formData.posterUrl && (
+                <div className="relative w-20 h-28 border rounded overflow-hidden">
+                  <Image
+                    src={formData.posterUrl}
+                    alt="포스터 미리보기"
+                    fill
+                    unoptimized
+                    className="object-cover"
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="backdropUpload" className="mb-3">
+              배경 이미지
+            </Label>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    document.getElementById('backdropUpload')?.click()
+                  }
+                  disabled={uploadImagesMutation.isPending}
+                  className="flex items-center gap-2"
+                >
+                  <Upload className="h-4 w-4" />
+                  {uploadImagesMutation.isPending
+                    ? '업로드 중...'
+                    : '이미지 선택'}
+                </Button>
+                {formData.backdropUrl && (
+                  <div className="flex items-center gap-2">
+                    <ImageIcon className="h-4 w-4 text-green-500" />
+                    <span className="text-sm text-green-600">업로드 완료</span>
+                  </div>
+                )}
+              </div>
+              <input
+                id="backdropUpload"
+                type="file"
+                accept="image/*"
+                onChange={(e) => handleImageUpload(e.target.files, 'backdrop')}
+                className="hidden"
+              />
+              {formData.backdropUrl && (
+                <div className="relative w-32 h-20 border rounded overflow-hidden">
+                  <Image
+                    src={formData.backdropUrl}
+                    alt="배경 이미지 미리보기"
+                    fill
+                    unoptimized
+                    className="object-cover"
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <Label htmlFor="trailerUrl" className="mb-3">
+            예고편 URL
+          </Label>
+          <Input
+            id="trailerUrl"
+            value={formData.trailerUrl}
+            onChange={(e) =>
+              updateFormData((prev) => ({
+                ...prev,
+                trailerUrl: e.target.value,
+              }))
+            }
+            className="mb-5"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/ContentFormSections/CastInfo.tsx
+++ b/src/components/admin/ContentFormSections/CastInfo.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Button } from '@components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
+import { Plus, X } from 'lucide-react';
+import Image from 'next/image';
+import type { ContentWithoutId } from '@type/admin/Content';
+
+interface CastInfoProps {
+  formData: ContentWithoutId;
+  setIsActorSearchOpen: (open: boolean) => void;
+  removeCast: (castToRemove: string) => void;
+}
+
+export default function CastInfo({
+  formData,
+  setIsActorSearchOpen,
+  removeCast,
+}: CastInfoProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="mt-5">출연진 정보</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Button
+          type="button"
+          onClick={() => setIsActorSearchOpen(true)}
+          className="w-full"
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          출연진 검색 및 추가
+        </Button>
+        <div className="space-y-2 mb-5">
+          {formData.casts.map((cast) => (
+            <div
+              key={cast.castId}
+              className="flex items-center justify-between p-2 border rounded"
+            >
+              <div className="flex items-center gap-2">
+                {cast.castImageUrl && (
+                  <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
+                    <Image
+                      src={cast.castImageUrl || '/placeholder.svg'}
+                      alt={cast.castName || '출연진 이미지'}
+                      fill
+                      unoptimized
+                      className="w-8 h-8 rounded-full object-cover"
+                    />
+                  </div>
+                )}
+                <span>{cast.castName}</span>
+              </div>
+              <Button
+                type="button"
+                className="cursor-pointer"
+                size="sm"
+                onClick={() => removeCast(cast.castName)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/ContentFormSections/CastInfo.tsx
+++ b/src/components/admin/ContentFormSections/CastInfo.tsx
@@ -41,7 +41,7 @@ export default function CastInfo({
                 {cast.castImageUrl && (
                   <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
                     <Image
-                      src={cast.castImageUrl || '/placeholder.svg'}
+                      src={cast.castImageUrl}
                       alt={cast.castName || '출연진 이미지'}
                       fill
                       unoptimized

--- a/src/components/admin/ContentFormSections/CastInfo.tsx
+++ b/src/components/admin/ContentFormSections/CastInfo.tsx
@@ -9,7 +9,7 @@ import type { ContentWithoutId } from '@type/admin/Content';
 interface CastInfoProps {
   formData: ContentWithoutId;
   setIsActorSearchOpen: (open: boolean) => void;
-  removeCast: (castToRemove: string) => void;
+  removeCast: (castIdToRemove: number) => void;
 }
 
 export default function CastInfo({
@@ -45,7 +45,7 @@ export default function CastInfo({
                       alt={cast.castName || '출연진 이미지'}
                       fill
                       unoptimized
-                      className="w-8 h-8 rounded-full object-cover"
+                      className="w-12 h-12 rounded-full object-cover"
                     />
                   </div>
                 )}
@@ -55,7 +55,7 @@ export default function CastInfo({
                 type="button"
                 className="cursor-pointer"
                 size="sm"
-                onClick={() => removeCast(cast.castName)}
+                onClick={() => removeCast(cast.castId)}
               >
                 <X className="h-4 w-4" />
               </Button>

--- a/src/components/admin/ContentFormSections/DetailedInfo.tsx
+++ b/src/components/admin/ContentFormSections/DetailedInfo.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { Input } from '@components/ui/input';
+import { Label } from '@components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/ui/select';
+import { Badge } from '@components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
+import { CONTENT_CATEGORIES, COUNTRIES } from '@/constants';
+import { getGenresByCategory } from '@lib/genres';
+import type { ContentWithoutId } from '@type/admin/Content';
+
+interface DetailedInfoProps {
+  formData: ContentWithoutId;
+  updateFormData: (
+    updater: (prev: ContentWithoutId) => ContentWithoutId,
+  ) => void;
+  addGenre: (selectedGenre: string) => void;
+  removeGenre: (genreToRemove: string) => void;
+  addCountry: (selected: string) => void;
+  removeCountry: (countryToRemove: string) => void;
+}
+
+export default function DetailedInfo({
+  formData,
+  updateFormData,
+  addGenre,
+  removeGenre,
+  addCountry,
+  removeCountry,
+}: DetailedInfoProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="mt-5">상세 정보</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <Label htmlFor="openDate" className="mb-3">
+              개봉일
+            </Label>
+            <Input
+              id="openDate"
+              type="date"
+              value={formData.openDate?.split('T')[0] || ''}
+              onChange={(e) =>
+                updateFormData((prev) => ({
+                  ...prev,
+                  openDate: e.target.value,
+                }))
+              }
+              className="dark:bg-gray-700 dark:text-black"
+            />
+          </div>
+          <div>
+            <Label htmlFor="runningTime" className="mb-3">
+              상영시간 (분)
+            </Label>
+            <Input
+              id="runningTime"
+              type="number"
+              min="0"
+              value={formData.runningTime}
+              onChange={(e) =>
+                updateFormData((prev) => ({
+                  ...prev,
+                  runningTime: Number(e.target.value) || 0,
+                }))
+              }
+            />
+          </div>
+          <div>
+            <Label htmlFor="episode" className="mb-3">
+              에피소드
+            </Label>
+            <Input
+              id="episode"
+              type="number"
+              min="0"
+              value={formData.episode}
+              onChange={(e) =>
+                updateFormData((prev) => ({
+                  ...prev,
+                  episode: Number(e.target.value) || 0,
+                }))
+              }
+            />
+          </div>
+        </div>
+
+        <div>
+          <Label htmlFor="category" className="mb-3">
+            카테고리 *
+          </Label>
+          <Select
+            value={formData.categories[0]?.categoryType || ''}
+            onValueChange={(value) => {
+              updateFormData((prev) => {
+                const updatedCategories = [...prev.categories];
+
+                if (updatedCategories[0]) {
+                  updatedCategories[0].categoryType = value;
+                  updatedCategories[0].genres = [];
+                } else {
+                  updatedCategories[0] = {
+                    categoryType: value,
+                    genres: [],
+                  };
+                }
+                return { ...prev, categories: updatedCategories };
+              });
+            }}
+          >
+            <SelectTrigger className="cursor-pointer">
+              <SelectValue placeholder="카테고리 선택" />
+            </SelectTrigger>
+            <SelectContent>
+              {CONTENT_CATEGORIES.map((category) => (
+                <SelectItem
+                  key={category}
+                  value={category}
+                  className="cursor-pointer"
+                >
+                  {category}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {formData.categories[0]?.categoryType && (
+          <div>
+            <Label className="mb-3">장르 *</Label>
+            <div className="flex flex-wrap gap-2 max-w-full">
+              {(() => {
+                const selectedCategory =
+                  formData.categories[0]?.categoryType || '';
+                const availableGenres = getGenresByCategory(selectedCategory);
+
+                return availableGenres.map((genre) => {
+                  const isSelected =
+                    formData.categories[0]?.genres.includes(genre);
+
+                  return (
+                    <Badge
+                      key={genre}
+                      variant={isSelected ? 'default' : 'secondary'}
+                      className={`cursor-pointer select-none ${
+                        isSelected ? 'bg-blue-600 text-white' : ''
+                      }`}
+                      onClick={() =>
+                        isSelected ? removeGenre(genre) : addGenre(genre)
+                      }
+                    >
+                      {genre}
+                    </Badge>
+                  );
+                });
+              })()}
+            </div>
+          </div>
+        )}
+
+        <div>
+          <Label className="mb-3">제작 국가</Label>
+          <div className="flex flex-wrap gap-2 mb-5 ">
+            {COUNTRIES.map((country) => {
+              const isSelected = formData.countries.includes(country);
+
+              return (
+                <Badge
+                  key={country}
+                  variant={isSelected ? 'default' : 'secondary'}
+                  className={`cursor-pointer select-none ${
+                    isSelected ? 'bg-green-600 text-white' : ''
+                  }`}
+                  onClick={() =>
+                    isSelected ? removeCountry(country) : addCountry(country)
+                  }
+                >
+                  {country}
+                </Badge>
+              );
+            })}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/ContentFormSections/DetailedInfo.tsx
+++ b/src/components/admin/ContentFormSections/DetailedInfo.tsx
@@ -34,6 +34,9 @@ export default function DetailedInfo({
   addCountry,
   removeCountry,
 }: DetailedInfoProps) {
+  const selectedCategory = formData.categories[0]?.categoryType || '';
+  const availableGenres = getGenresByCategory(selectedCategory);
+
   return (
     <Card>
       <CardHeader>
@@ -48,14 +51,18 @@ export default function DetailedInfo({
             <Input
               id="openDate"
               type="date"
-              value={formData.openDate?.split('T')[0] || ''}
+              value={
+                formData.openDate?.includes('T')
+                  ? formData.openDate.split('T')[0]
+                  : formData.openDate || ''
+              }
               onChange={(e) =>
                 updateFormData((prev) => ({
                   ...prev,
                   openDate: e.target.value,
                 }))
               }
-              className="dark:bg-gray-700 dark:text-black"
+              className="dark:bg-gray-700 dark:text-white"
             />
           </div>
           <div>
@@ -102,18 +109,15 @@ export default function DetailedInfo({
             value={formData.categories[0]?.categoryType || ''}
             onValueChange={(value) => {
               updateFormData((prev) => {
-                const updatedCategories = [...prev.categories];
-
-                if (updatedCategories[0]) {
-                  updatedCategories[0].categoryType = value;
-                  updatedCategories[0].genres = [];
-                } else {
-                  updatedCategories[0] = {
-                    categoryType: value,
-                    genres: [],
-                  };
-                }
-                return { ...prev, categories: updatedCategories };
+                return {
+                  ...prev,
+                  categories: [
+                    {
+                      categoryType: value,
+                      genres: [],
+                    },
+                  ],
+                };
               });
             }}
           >
@@ -138,38 +142,32 @@ export default function DetailedInfo({
           <div>
             <Label className="mb-3">장르 *</Label>
             <div className="flex flex-wrap gap-2 max-w-full">
-              {(() => {
-                const selectedCategory =
-                  formData.categories[0]?.categoryType || '';
-                const availableGenres = getGenresByCategory(selectedCategory);
+              {availableGenres.map((genre) => {
+                const isSelected =
+                  formData.categories[0]?.genres.includes(genre);
 
-                return availableGenres.map((genre) => {
-                  const isSelected =
-                    formData.categories[0]?.genres.includes(genre);
-
-                  return (
-                    <Badge
-                      key={genre}
-                      variant={isSelected ? 'default' : 'secondary'}
-                      className={`cursor-pointer select-none ${
-                        isSelected ? 'bg-blue-600 text-white' : ''
-                      }`}
-                      onClick={() =>
-                        isSelected ? removeGenre(genre) : addGenre(genre)
-                      }
-                    >
-                      {genre}
-                    </Badge>
-                  );
-                });
-              })()}
+                return (
+                  <Badge
+                    key={genre}
+                    variant={isSelected ? 'default' : 'secondary'}
+                    className={`cursor-pointer select-none ${
+                      isSelected ? 'bg-blue-600 text-white' : ''
+                    }`}
+                    onClick={() =>
+                      isSelected ? removeGenre(genre) : addGenre(genre)
+                    }
+                  >
+                    {genre}
+                  </Badge>
+                );
+              })}
             </div>
           </div>
         )}
 
         <div>
           <Label className="mb-3">제작 국가</Label>
-          <div className="flex flex-wrap gap-2 mb-5 ">
+          <div className="flex flex-wrap gap-2 mb-5">
             {COUNTRIES.map((country) => {
               const isSelected = formData.countries.includes(country);
 

--- a/src/components/admin/ContentFormSections/DirectorInfo.tsx
+++ b/src/components/admin/ContentFormSections/DirectorInfo.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Button } from '@components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
+import { Plus, X } from 'lucide-react';
+import Image from 'next/image';
+import type { ContentWithoutId } from '@type/admin/Content';
+
+interface DirectorInfoProps {
+  formData: ContentWithoutId;
+  setIsDirectorSearchOpen: (open: boolean) => void;
+  removeDirector: (directorToRemove: string) => void;
+}
+
+export default function DirectorInfo({
+  formData,
+  setIsDirectorSearchOpen,
+  removeDirector,
+}: DirectorInfoProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="mt-5">감독 정보</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Button
+          type="button"
+          onClick={() => setIsDirectorSearchOpen(true)}
+          className="w-full"
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          감독 검색 및 추가
+        </Button>
+        <div className="space-y-2 mb-5">
+          {formData.directors.map((director) => (
+            <div
+              key={director.directorId}
+              className="flex items-center justify-between p-2 border rounded"
+            >
+              <div className="flex items-center gap-2">
+                {director.directorImageUrl && (
+                  <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
+                    <Image
+                      src={director.directorImageUrl || '/placeholder.svg'}
+                      alt={director.directorName || '감독 이미지'}
+                      fill
+                      unoptimized
+                      className="w-8 h-8 rounded-full object-cover"
+                    />
+                  </div>
+                )}
+                <span>{director.directorName}</span>
+              </div>
+              <Button
+                type="button"
+                className="cursor-pointer"
+                size="sm"
+                onClick={() => removeDirector(director.directorName)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/ContentFormSections/DirectorInfo.tsx
+++ b/src/components/admin/ContentFormSections/DirectorInfo.tsx
@@ -41,7 +41,7 @@ export default function DirectorInfo({
                 {director.directorImageUrl && (
                   <div className="relative w-12 h-12 rounded-full overflow-hidden shrink-0">
                     <Image
-                      src={director.directorImageUrl || '/placeholder.svg'}
+                      src={director.directorImageUrl}
                       alt={director.directorName || '감독 이미지'}
                       fill
                       unoptimized

--- a/src/components/admin/ContentFormSections/DirectorInfo.tsx
+++ b/src/components/admin/ContentFormSections/DirectorInfo.tsx
@@ -9,7 +9,7 @@ import type { ContentWithoutId } from '@type/admin/Content';
 interface DirectorInfoProps {
   formData: ContentWithoutId;
   setIsDirectorSearchOpen: (open: boolean) => void;
-  removeDirector: (directorToRemove: string) => void;
+  removeDirector: (directorIdToRemove: number) => void;
 }
 
 export default function DirectorInfo({
@@ -45,7 +45,7 @@ export default function DirectorInfo({
                       alt={director.directorName || '감독 이미지'}
                       fill
                       unoptimized
-                      className="w-8 h-8 rounded-full object-cover"
+                      className="w-12 h-12 rounded-full object-cover"
                     />
                   </div>
                 )}
@@ -55,7 +55,7 @@ export default function DirectorInfo({
                 type="button"
                 className="cursor-pointer"
                 size="sm"
-                onClick={() => removeDirector(director.directorName)}
+                onClick={() => removeDirector(director.directorId)}
               >
                 <X className="h-4 w-4" />
               </Button>

--- a/src/components/admin/ContentFormSections/PlatformInfo.tsx
+++ b/src/components/admin/ContentFormSections/PlatformInfo.tsx
@@ -68,7 +68,7 @@ export default function PlatformSection({
             placeholder="시청 URL"
           />
         </div>
-        <div className="flex items-center space-x-2 mb-3"></div>
+
         <Button
           type="button"
           onClick={addPlatform}
@@ -80,7 +80,7 @@ export default function PlatformSection({
         <div className="space-y-2">
           {formData.platforms.map((platform, index) => (
             <div
-              key={index}
+              key={`${platform.platformType}-${platform.watchUrl}`}
               className="flex items-center justify-between p-2 border rounded"
             >
               <div>

--- a/src/components/admin/ContentFormSections/PlatformInfo.tsx
+++ b/src/components/admin/ContentFormSections/PlatformInfo.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { Button } from '@components/ui/button';
+import { Input } from '@components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/ui/select';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
+import { Plus, X } from 'lucide-react';
+import { PLATFORMS } from '@lib/platforms';
+import type { ContentWithoutId, PlatformInfo } from '@type/admin/Content';
+
+interface PlatformSectionProps {
+  formData: ContentWithoutId;
+  newPlatform: PlatformInfo;
+  setNewPlatform: (platform: PlatformInfo) => void;
+  addPlatform: () => void;
+  removePlatform: (index: number) => void;
+}
+
+export default function PlatformSection({
+  formData,
+  newPlatform,
+  setNewPlatform,
+  addPlatform,
+  removePlatform,
+}: PlatformSectionProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="mt-5">시청 플랫폼 *</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 mb-5">
+        <div className="grid grid-cols-2 gap-2 mb-2">
+          <Select
+            value={newPlatform.platformType}
+            onValueChange={(value) =>
+              setNewPlatform({
+                ...newPlatform,
+                platformType: value,
+              })
+            }
+          >
+            <SelectTrigger className="cursor-pointer">
+              <SelectValue placeholder="플랫폼 선택" />
+            </SelectTrigger>
+            <SelectContent>
+              {PLATFORMS.map((platform) => (
+                <SelectItem
+                  key={platform.id}
+                  value={platform.label}
+                  className="cursor-pointer"
+                >
+                  {platform.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Input
+            value={newPlatform.watchUrl}
+            onChange={(e) =>
+              setNewPlatform({ ...newPlatform, watchUrl: e.target.value })
+            }
+            placeholder="시청 URL"
+          />
+        </div>
+        <div className="flex items-center space-x-2 mb-3"></div>
+        <Button
+          type="button"
+          onClick={addPlatform}
+          className="w-full mb-10 cursor-pointer"
+        >
+          <Plus className="h-4 w-4 mr-2" />
+          플랫폼 추가
+        </Button>
+        <div className="space-y-2">
+          {formData.platforms.map((platform, index) => (
+            <div
+              key={index}
+              className="flex items-center justify-between p-2 border rounded"
+            >
+              <div>
+                <div className="font-medium">{platform.platformType}</div>
+                <div className="text-sm text-gray-500">{platform.watchUrl}</div>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                className="cursor-pointer"
+                size="sm"
+                onClick={() => removePlatform(index)}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/admin/bulkPersonRegistration.tsx
+++ b/src/components/admin/bulkPersonRegistration.tsx
@@ -180,9 +180,7 @@ export default function BulkPersonRegistration() {
 
     const castData = {
       casts: casts.map((cast) => {
-        const imageUrl = cast.profileImageFile
-          ? imageUrlMap.get(cast.id) || ''
-          : '';
+        const imageUrl = imageUrlMap.get(cast.id) || '';
         return {
           castName: cast.name,
           castImageUrl: imageUrl,
@@ -200,9 +198,7 @@ export default function BulkPersonRegistration() {
 
     const directorData = {
       directors: directors.map((director) => {
-        const imageUrl = director.profileImageFile
-          ? imageUrlMap.get(director.id) || ''
-          : '';
+        const imageUrl = imageUrlMap.get(director.id) || '';
         return {
           directorName: director.name,
           directorImageUrl: imageUrl,

--- a/src/components/admin/bulkPersonRegistration.tsx
+++ b/src/components/admin/bulkPersonRegistration.tsx
@@ -148,10 +148,16 @@ export default function BulkPersonRegistration() {
       if (person.profileImageFile) {
         const uploadPromise = uploadImagesMutation
           .mutateAsync([person.profileImageFile])
-          .then((response) => response.data.uploadedFileUrls[0]);
+          .then((response) => response.data.uploadedFileUrls[0])
+          .catch(() => ''); // 업로드 실패 시 빈 문자열 반환
         imageUploadMap.set(person.id, uploadPromise);
       } else {
-        imageUploadMap.set(person.id, Promise.resolve(person.profileImageUrl));
+        // blob URL인 경우 빈 문자열로 설정
+        const imageUrl =
+          person.profileImageUrl && person.profileImageUrl.startsWith('blob:')
+            ? ''
+            : person.profileImageUrl;
+        imageUploadMap.set(person.id, Promise.resolve(imageUrl));
       }
     });
 

--- a/src/components/admin/bulkPersonRegistration.tsx
+++ b/src/components/admin/bulkPersonRegistration.tsx
@@ -3,11 +3,11 @@
 import type React from 'react';
 
 import { useState, useEffect } from 'react';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Button } from '@components/ui/button';
+import { Input } from '@components/ui/input';
+import { Label } from '@components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@components/ui/card';
+import { Badge } from '@components/ui/badge';
 
 import {
   Select,

--- a/src/components/admin/bulkPersonRegistration.tsx
+++ b/src/components/admin/bulkPersonRegistration.tsx
@@ -23,6 +23,7 @@ import { usePostAdminDirectors } from '@hooks/admin/usePostDirectors';
 import { Cast, Director } from '@type/admin/Content';
 
 import Image from 'next/image';
+import { showSimpleToast } from '@components/common/Toast';
 
 interface PersonData {
   id: string;
@@ -222,7 +223,9 @@ export default function BulkPersonRegistration() {
       // 폼 초기화
       setPersons([]);
     } catch {
-      // 에러 처리 없음
+      showSimpleToast.error({
+        message: '인물 등록에 실패했습니다.',
+      });
     } finally {
       setIsLoading(false);
     }

--- a/src/components/admin/bulkPersonRegistration.tsx
+++ b/src/components/admin/bulkPersonRegistration.tsx
@@ -222,6 +222,8 @@ export default function BulkPersonRegistration() {
 
       // 폼 초기화
       setPersons([]);
+
+      showSimpleToast.success({ message: '인물 등록이 완료되었습니다.' });
     } catch {
       showSimpleToast.error({
         message: '인물 등록에 실패했습니다.',

--- a/src/components/admin/bulkPersonRegistration.tsx
+++ b/src/components/admin/bulkPersonRegistration.tsx
@@ -1,0 +1,401 @@
+'use client';
+
+import type React from 'react';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@components/ui/select';
+import { X, Plus, Upload, Users, Loader2 } from 'lucide-react';
+import { usePostUploadImages } from '@hooks/admin/usePostUploadImages';
+import { usePostAdminCasts } from '@hooks/admin/usePostCasts';
+import { usePostAdminDirectors } from '@hooks/admin/usePostDirectors';
+import { Cast, Director } from '@type/admin/Content';
+
+import Image from 'next/image';
+
+interface PersonData {
+  id: string;
+  name: string;
+  role: 'cast' | 'director';
+  profileImageFile: File | null;
+  profileImageUrl: string;
+}
+
+export default function BulkPersonRegistration() {
+  const [persons, setPersons] = useState<PersonData[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [nextId, setNextId] = useState(0);
+
+  // blob URL cleanup
+  useEffect(() => {
+    return () => {
+      persons.forEach((person) => {
+        if (
+          person.profileImageUrl &&
+          person.profileImageUrl.startsWith('blob:')
+        ) {
+          URL.revokeObjectURL(person.profileImageUrl);
+        }
+      });
+    };
+  }, [persons]);
+
+  // 훅들
+  const uploadImagesMutation = usePostUploadImages();
+  const postCastsMutation = usePostAdminCasts();
+  const postDirectorsMutation = usePostAdminDirectors();
+
+  const addNewPerson = () => {
+    const newPerson: PersonData = {
+      id: nextId.toString(),
+      name: '',
+      role: 'cast',
+      profileImageFile: null,
+      profileImageUrl: '',
+    };
+    setPersons([...persons, newPerson]);
+    setNextId(nextId + 1);
+  };
+
+  const removePerson = (id: string) => {
+    setPersons(persons.filter((person) => person.id !== id));
+  };
+
+  const updatePerson = (
+    id: string,
+    field: keyof PersonData,
+    value: string | File | null,
+  ) => {
+    setPersons(
+      persons.map((person) =>
+        person.id === id
+          ? {
+              ...person,
+              [field]: value,
+            }
+          : person,
+      ),
+    );
+  };
+
+  const handleImageUpload = (
+    id: string,
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      // 기존 blob URL 정리
+      const currentPerson = persons.find((p) => p.id === id);
+      if (
+        currentPerson?.profileImageUrl &&
+        currentPerson.profileImageUrl.startsWith('blob:')
+      ) {
+        URL.revokeObjectURL(currentPerson.profileImageUrl);
+      }
+
+      // 로컬 미리보기용 URL 생성
+      const previewUrl = URL.createObjectURL(file);
+
+      // 한 번에 모든 필드 업데이트
+      setPersons(
+        persons.map((person) =>
+          person.id === id
+            ? {
+                ...person,
+                profileImageFile: file,
+                profileImageUrl: previewUrl,
+              }
+            : person,
+        ),
+      );
+    }
+  };
+
+  const validatePersons = () => {
+    const errors: string[] = [];
+    persons.forEach((person, index) => {
+      if (!person.name.trim()) {
+        errors.push(`${index + 1}번째 인물의 이름이 필요합니다.`);
+      }
+    });
+    return errors;
+  };
+
+  const handleBulkRegistration = async () => {
+    const validationErrors = validatePersons();
+    if (validationErrors.length > 0) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      // 배우와 감독을 분리
+      const casts = persons.filter((person) => person.role === 'cast');
+      const directors = persons.filter((person) => person.role === 'director');
+
+      // 이미지 업로드 처리 - id와 함께 관리
+      const imageUploadMap = new Map<string, Promise<string>>();
+
+      // 배우 이미지 업로드
+      casts.forEach((cast) => {
+        if (cast.profileImageFile) {
+          const uploadPromise = uploadImagesMutation
+            .mutateAsync([cast.profileImageFile])
+            .then((response) => response.data.uploadedFileUrls[0]);
+          imageUploadMap.set(cast.id, uploadPromise);
+        } else {
+          imageUploadMap.set(cast.id, Promise.resolve(cast.profileImageUrl));
+        }
+      });
+
+      // 감독 이미지 업로드
+      directors.forEach((director) => {
+        if (director.profileImageFile) {
+          const uploadPromise = uploadImagesMutation
+            .mutateAsync([director.profileImageFile])
+            .then((response) => response.data.uploadedFileUrls[0]);
+          imageUploadMap.set(director.id, uploadPromise);
+        } else {
+          imageUploadMap.set(
+            director.id,
+            Promise.resolve(director.profileImageUrl),
+          );
+        }
+      });
+
+      // 모든 이미지 업로드 완료 대기
+      const uploadedImageUrls = await Promise.all(imageUploadMap.values());
+      const imageUrlMap = new Map<string, string>();
+
+      // id와 업로드된 URL을 매핑
+      const personIds = Array.from(imageUploadMap.keys());
+      personIds.forEach((id, index) => {
+        imageUrlMap.set(id, uploadedImageUrls[index]);
+      });
+
+      // 배우 등록
+      if (casts.length > 0) {
+        const castData = {
+          casts: casts.map((cast) => {
+            // 이미지 파일이 있는 경우에만 업로드된 URL 사용, 없으면 빈 문자열
+            const imageUrl = cast.profileImageFile
+              ? imageUrlMap.get(cast.id) || ''
+              : '';
+            return {
+              castName: cast.name,
+              castImageUrl: imageUrl,
+            } as Omit<Cast, 'castId'>;
+          }),
+        };
+        await postCastsMutation.mutateAsync(castData);
+      }
+
+      // 감독 등록
+      if (directors.length > 0) {
+        const directorData = {
+          directors: directors.map((director) => {
+            // 이미지 파일이 있는 경우에만 업로드된 URL 사용, 없으면 빈 문자열
+            const imageUrl = director.profileImageFile
+              ? imageUrlMap.get(director.id) || ''
+              : '';
+            return {
+              directorName: director.name,
+              directorImageUrl: imageUrl,
+            } as Omit<Director, 'directorId'>;
+          }),
+        };
+        await postDirectorsMutation.mutateAsync(directorData);
+      }
+
+      // 폼 초기화
+      setPersons([]);
+    } catch {
+      // 에러 처리 없음
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">인물 다량 등록</h3>
+          <p className="text-sm text-gray-600">
+            여러 명의 배우와 감독을 한 번에 등록할 수 있습니다.
+          </p>
+        </div>
+        <Button type="button" onClick={addNewPerson} disabled={isLoading}>
+          <Plus className="h-4 w-4 mr-2" />
+          인물 추가
+        </Button>
+      </div>
+
+      {/* 인물 목록 */}
+      <div className="space-y-4">
+        {persons.map((person, index) => (
+          <Card key={person.id}>
+            <CardHeader className="pb-3">
+              <div className="flex items-center justify-between">
+                <CardTitle className="text-base">
+                  {index + 1}번째 인물
+                  {person.name && (
+                    <Badge variant="outline" className="ml-2">
+                      {person.name}
+                    </Badge>
+                  )}
+                  <Badge
+                    variant={person.role === 'cast' ? 'default' : 'secondary'}
+                    className="ml-2"
+                  >
+                    {person.role === 'cast' ? '배우' : '감독'}
+                  </Badge>
+                </CardTitle>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removePerson(person.id)}
+                  disabled={isLoading}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label>이름 *</Label>
+                  <Input
+                    value={person.name}
+                    onChange={(e) =>
+                      updatePerson(person.id, 'name', e.target.value)
+                    }
+                    placeholder="이름 입력"
+                    disabled={isLoading}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>역할</Label>
+                  <Select
+                    value={person.role}
+                    onValueChange={(value) =>
+                      updatePerson(person.id, 'role', value)
+                    }
+                    disabled={isLoading}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="cast">배우</SelectItem>
+                      <SelectItem value="director">감독</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>프로필 이미지</Label>
+                  <div className="flex gap-2">
+                    <Input
+                      type="file"
+                      accept="image/*"
+                      onChange={(e) => handleImageUpload(person.id, e)}
+                      className="hidden"
+                      id={`image-upload-${person.id}`}
+                      disabled={isLoading}
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() =>
+                        document
+                          .getElementById(`image-upload-${person.id}`)
+                          ?.click()
+                      }
+                      className="flex-1"
+                      disabled={isLoading}
+                    >
+                      <Upload className="h-4 w-4 mr-2" />
+                      이미지 업로드
+                    </Button>
+                  </div>
+                  {person.profileImageUrl && (
+                    <div className="mt-2 mb-2">
+                      <Image
+                        src={person.profileImageUrl || '/placeholder.svg'}
+                        alt="미리보기"
+                        width={64}
+                        height={64}
+                        className="w-16 h-16 rounded-full object-cover"
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* 등록 버튼 */}
+      {persons.length > 0 && (
+        <div className="flex justify-end gap-2 pt-4 border-t">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setPersons([])}
+            disabled={isLoading}
+          >
+            전체 초기화
+          </Button>
+          <Button
+            type="button"
+            onClick={handleBulkRegistration}
+            disabled={
+              isLoading ||
+              persons.length === 0 ||
+              uploadImagesMutation.isPending ||
+              postCastsMutation.isPending ||
+              postDirectorsMutation.isPending
+            }
+          >
+            {isLoading ||
+            uploadImagesMutation.isPending ||
+            postCastsMutation.isPending ||
+            postDirectorsMutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                등록 중...
+              </>
+            ) : (
+              `${persons.length}명 일괄 등록`
+            )}
+          </Button>
+        </div>
+      )}
+
+      {persons.length === 0 && (
+        <div className="text-center py-12 text-gray-500">
+          <Users className="h-12 w-12 mx-auto mb-4 text-gray-300" />
+          <p>등록할 인물을 추가해주세요.</p>
+          <p className="text-sm">
+            배우와 감독을 한 번에 여러 명 등록할 수 있습니다.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/admin/bulkPersonRegistration.tsx
+++ b/src/components/admin/bulkPersonRegistration.tsx
@@ -2,7 +2,7 @@
 
 import type React from 'react';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Button } from '@components/ui/button';
 import { Input } from '@components/ui/input';
 import { Label } from '@components/ui/label';
@@ -37,6 +37,7 @@ export default function BulkPersonRegistration() {
   const [persons, setPersons] = useState<PersonData[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [nextId, setNextId] = useState(0);
+  const refs = useRef<{ [key: string]: HTMLInputElement | null }>({});
 
   // blob URL cleanup
   useEffect(() => {
@@ -319,17 +320,15 @@ export default function BulkPersonRegistration() {
                       accept="image/*"
                       onChange={(e) => handleImageUpload(person.id, e)}
                       className="hidden"
-                      id={`image-upload-${person.id}`}
+                      ref={(el) => {
+                        refs.current[person.id] = el;
+                      }}
                       disabled={isLoading}
                     />
                     <Button
                       type="button"
                       variant="outline"
-                      onClick={() =>
-                        document
-                          .getElementById(`image-upload-${person.id}`)
-                          ?.click()
-                      }
+                      onClick={() => refs.current[person.id]?.click()}
                       className="flex-1"
                       disabled={isLoading}
                     >

--- a/src/components/admin/dialogs/actorSearchDialog.tsx
+++ b/src/components/admin/dialogs/actorSearchDialog.tsx
@@ -207,6 +207,7 @@ export default function CastSearchDialog({
           castImageUrl: '',
         });
         setShowAddForm(false);
+        showSimpleToast.success({ message: '배우 등록이 완료되었습니다.' });
       }
     } catch {
       showSimpleToast.error({

--- a/src/components/admin/dialogs/actorSearchDialog.tsx
+++ b/src/components/admin/dialogs/actorSearchDialog.tsx
@@ -385,6 +385,7 @@ export default function CastSearchDialog({
                                       alt={cast.castName}
                                       width={48}
                                       height={48}
+                                      unoptimized
                                       className="w-12 h-12 rounded-full object-cover"
                                     />
                                   ) : (
@@ -495,6 +496,7 @@ export default function CastSearchDialog({
                         alt="미리보기"
                         width={64}
                         height={64}
+                        unoptimized
                         className="w-16 h-16 rounded-full object-cover"
                       />
                     </div>

--- a/src/components/admin/dialogs/actorSearchDialog.tsx
+++ b/src/components/admin/dialogs/actorSearchDialog.tsx
@@ -56,6 +56,7 @@ export default function CastSearchDialog({
 
   // 무한 스크롤용 ref
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const castImageRef = useRef<HTMLInputElement>(null);
 
   // 이미지 업로드 및 배우 등록 훅
   const uploadImagesMutation = usePostUploadImages();
@@ -475,14 +476,12 @@ export default function CastSearchDialog({
                       accept="image/*"
                       onChange={handleImageUpload}
                       className="hidden"
-                      id="cast-image-upload"
+                      ref={castImageRef}
                     />
                     <Button
                       type="button"
                       variant="outline"
-                      onClick={() =>
-                        document.getElementById('cast-image-upload')?.click()
-                      }
+                      onClick={() => castImageRef.current?.click()}
                       className="flex-1"
                     >
                       <Upload className="h-4 w-4 mr-2" />

--- a/src/components/admin/dialogs/directorSearchDialog.tsx
+++ b/src/components/admin/dialogs/directorSearchDialog.tsx
@@ -404,6 +404,7 @@ export default function DirectorSearchDialog({
                                       alt={director.directorName}
                                       width={48}
                                       height={48}
+                                      unoptimized
                                       className="w-12 h-12 rounded-full object-cover"
                                     />
                                   ) : (
@@ -517,6 +518,7 @@ export default function DirectorSearchDialog({
                         alt="미리보기"
                         width={64}
                         height={64}
+                        unoptimized
                         className="w-16 h-16 rounded-full object-cover"
                       />
                     </div>

--- a/src/components/admin/dialogs/directorSearchDialog.tsx
+++ b/src/components/admin/dialogs/directorSearchDialog.tsx
@@ -216,6 +216,7 @@ export default function DirectorSearchDialog({
         });
         setShowAddForm(false);
       }
+      showSimpleToast.success({ message: '감독 등록이 완료되었습니다.' });
     } catch {
       showSimpleToast.error({
         message: '감독 등록에 실패했습니다.',

--- a/src/components/admin/dialogs/directorSearchDialog.tsx
+++ b/src/components/admin/dialogs/directorSearchDialog.tsx
@@ -58,6 +58,7 @@ export default function DirectorSearchDialog({
 
   // 무한 스크롤용 ref
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
+  const directorImageRef = useRef<HTMLInputElement>(null);
 
   // 이미지 업로드 및 감독 등록 훅
   const uploadImagesMutation = usePostUploadImages();
@@ -497,16 +498,12 @@ export default function DirectorSearchDialog({
                       accept="image/*"
                       onChange={handleImageUpload}
                       className="hidden"
-                      id="director-image-upload"
+                      ref={directorImageRef}
                     />
                     <Button
                       type="button"
                       variant="outline"
-                      onClick={() =>
-                        document
-                          .getElementById('director-image-upload')
-                          ?.click()
-                      }
+                      onClick={() => directorImageRef.current?.click()}
                       className="flex-1"
                     >
                       <Upload className="h-4 w-4 mr-2" />

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -171,7 +171,7 @@ export const showInteractiveToast = {
         <div
           className={[
             'flex flex-col gap-3',
-            'text-sm text-gray-800 rounded-xl border border-gray-200 p-4',
+            'text-sm text-white rounded-xl border border-gray-200 p-4',
             'bg-gray-100 shadow-lg',
             opts.className,
             'animate-enter',
@@ -189,7 +189,7 @@ export const showInteractiveToast = {
                   opts.onCancel?.();
                   toast.dismiss(id);
                 }}
-                className="h-8 px-3"
+                className="h-8 px-3 text-black"
               >
                 {opts.cancelText ?? '취소'}
               </Button>

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -171,7 +171,7 @@ export const showInteractiveToast = {
         <div
           className={[
             'flex flex-col gap-3',
-            'text-sm text-white rounded-xl border border-gray-200 p-4',
+            'text-sm text-gray-800 rounded-xl border border-gray-200 p-4',
             'bg-gray-100 shadow-lg',
             opts.className,
             'animate-enter',

--- a/src/hooks/admin/usePostCasts.ts
+++ b/src/hooks/admin/usePostCasts.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { showSimpleToast } from '@components/common/Toast';
 import { postAdminCasts } from '@lib/apis/admin/postCasts';
 
 /**
@@ -10,12 +9,7 @@ export const usePostAdminCasts = () => {
 
   return useMutation({
     mutationFn: postAdminCasts,
-    onSuccess: (data) => {
-      showSimpleToast.success({
-        message: `${data.castIds.length}명의 출연진이 등록되었습니다.`,
-        position: 'top-center',
-      });
-
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['infiniteAdminCasts'] });
     },
   });

--- a/src/hooks/admin/usePostCasts.ts
+++ b/src/hooks/admin/usePostCasts.ts
@@ -18,11 +18,5 @@ export const usePostAdminCasts = () => {
 
       queryClient.invalidateQueries({ queryKey: ['infiniteAdminCasts'] });
     },
-    onError: () => {
-      showSimpleToast.error({
-        message: '출연진 등록에 실패했습니다.',
-        position: 'top-center',
-      });
-    },
   });
 };

--- a/src/hooks/admin/usePostDirectors.ts
+++ b/src/hooks/admin/usePostDirectors.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { showSimpleToast } from '@components/common/Toast';
 import { postAdminDirectors } from '@lib/apis/admin/postDirectors';
 
 /**
@@ -10,12 +9,7 @@ export const usePostAdminDirectors = () => {
 
   return useMutation({
     mutationFn: postAdminDirectors,
-    onSuccess: (data) => {
-      showSimpleToast.success({
-        message: `${data.directorIds.length}명의 감독이 등록되었습니다.`,
-        position: 'top-center',
-      });
-
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['infiniteAdminDirectors'] });
     },
   });

--- a/src/hooks/admin/usePostDirectors.ts
+++ b/src/hooks/admin/usePostDirectors.ts
@@ -18,11 +18,5 @@ export const usePostAdminDirectors = () => {
 
       queryClient.invalidateQueries({ queryKey: ['infiniteAdminDirectors'] });
     },
-    onError: () => {
-      showSimpleToast.error({
-        message: '감독 등록에 실패했습니다.',
-        position: 'top-center',
-      });
-    },
   });
 };

--- a/src/hooks/admin/usePostUploadImages.ts
+++ b/src/hooks/admin/usePostUploadImages.ts
@@ -1,12 +1,8 @@
 import { useMutation } from '@tanstack/react-query';
 import { postUploadImages } from '@lib/apis/admin/postUploadImages';
-import { showSimpleToast } from '@components/common/Toast';
 
 export const usePostUploadImages = () => {
   return useMutation({
     mutationFn: postUploadImages,
-    onError: () => {
-      showSimpleToast.error({ message: '이미지 업로드에 실패했습니다.' });
-    },
   });
 };


### PR DESCRIPTION
## #️⃣연관된 이슈 

UDT-229-feat/admin-bulk-person-create

## 📝작업 내용

- 우측 탭 - 인물 등록 탭 (여러 명의 배우, 감독 일괄 등록 할 수 있는) 구현
- 이미지 업로드, 새 배우 등록, 새 감독 등록 시 성공 toast랑 에러 toast try-catch 문 안에서 수행하도록 변경하였습니다.
- 기존의 contentform 파일 (콘텐츠 등록 폼) 을 ContentFormSections 포더 아래에 5개의 파일 (BasicInfo, DetailedInfo, CastInfo, DirectorInfo, PlatformInfo) 로 분리하여 가독성을 높였습니다. 


### 스크린샷 (선택)
화면녹화 했는데 왜 자꾸 내거 동영상 올리면 검은화면만 나오고 안나오는지 속상.,


## 💬리뷰 요구사항(선택)

> Reviewer가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
