### PR TITLE
[UDT-241] 탐색 페이지에서 가로 스크롤 방지 및 PosterCard에서 <Image> 컴포넌트에 대해 onLoad property로 변경

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -58,8 +58,8 @@ export default function ExplorePage() {
       {/* 2. FilterRadioButtonGroup의 sticky 옵션은 해당 컴포넌트 내부에 둔다! */}
       <FilterRadioButtonGroup />
 
-      {/* 3. 나머지 모든 콘텐츠가 스크롤되는 영역 (여기에서만 overflow-y-auto 속성 사용) */}
-      <div className="flex-1 flex flex-col h-full overflow-y-auto pb-15">
+      {/* 3. 나머지 모든 콘텐츠가 스크롤되는 영역 (여기에서만 overflow-y-auto 속성 사용, 가로 스크롤은 방지) */}
+      <div className="flex-1 flex flex-col h-full overflow-x-hidden overflow-y-auto pb-15">
         {filters !== undefined ? (
           <PosterCardsGrid
             contents={contents}

--- a/src/components/explore/PosterCard.tsx
+++ b/src/components/explore/PosterCard.tsx
@@ -97,7 +97,7 @@ export const PosterCard = forwardRef<HTMLDivElement, PosterCardProps>(
           width={dimensions.width}
           height={dimensions.height}
           onError={handleError}
-          onLoadingComplete={handleLoadComplete}
+          onLoad={handleLoadComplete}
           unoptimized
           style={{
             position: hasLoaded ? 'static' : 'absolute',


### PR DESCRIPTION
## #️⃣연관된 이슈
UDT-241

## 📝작업 내용
- 탐색 페이지 최상단 `page.tsx`에서 가로 스크롤 방지를 위해서 "나머지 모든 콘텐츠가 스크롤되는 영역"에 대해서 `overflow-x-hidden` 옵션  추가
- `PosterCard` 컴포넌트 속 `<Image>`에 대해, `onLoadingComplete` 대신 `onLoad` property 활용 (depercated 된 property 사용 지양을 위함)

## 스크린샷
`onLoadingComplete` 대신 `onLoad` 프로퍼티를 사용하니, 경고 로그가 무지막지하게 떴던 것이 말끔해 해결되었습늬다^^
<img width="1243" height="867" alt="스크린샷 2025-08-05 11 10 51" src="https://github.com/user-attachments/assets/64ae3bca-8006-424c-a6b5-81e2b13069dd" />


## 💬리뷰 요구사항
- 혹여나 추가적으로 탐색 페이지에서 문제가 발생하는 점이 있다면 말씀해 주세요!


## ✅ 체크리스트
- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
