### PR TITLE
[UDT-247] AppleTV 선택지 삭제

### DIFF
--- a/src/components/explore/OttCircleOption.tsx
+++ b/src/components/explore/OttCircleOption.tsx
@@ -6,7 +6,6 @@ import { getPlatformLogo } from '@utils/getPlatformLogo';
 // OTT Label 타입 정의
 type OttLabel =
   | '넷플릭스'
-  | '애플티비'
   | '티빙'
   | '디즈니+'
   | '웨이브'

--- a/src/components/profile/MovieCard.tsx
+++ b/src/components/profile/MovieCard.tsx
@@ -12,7 +12,6 @@ const fallbackUrls: Record<string, string> = {
   웨이브: 'https://www.wavve.com',
   '디즈니+': 'https://www.disneyplus.com',
   왓챠: 'https://watcha.com',
-  애플티비: 'https://tv.apple.com',
 };
 
 const MovieCard = ({

--- a/src/constants/FilterData.ts
+++ b/src/constants/FilterData.ts
@@ -19,7 +19,6 @@ export const PLATFORMS = [
   '왓챠',
   '티빙',
   '쿠팡플레이',
-  '애플티비',
 ] as const;
 
 export const GENRES = [

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -31,7 +31,6 @@ export const PLATFORMS = [
   '왓챠',
   '티빙',
   '쿠팡플레이',
-  '애플티비',
 ] as const;
 
 export const GENRES = [

--- a/src/lib/platforms.ts
+++ b/src/lib/platforms.ts
@@ -7,5 +7,4 @@ export const PLATFORMS: Platform[] = [
   { label: '웨이브', id: 'wavve' },
   { label: '디즈니+', id: 'disneyPlus' },
   { label: '왓챠', id: 'watcha' },
-  { label: '애플티비', id: 'appleTv' },
 ];

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -25,14 +25,7 @@ interface ReissueResult {
 /* -------------------------------------------------------------------------- */
 /* 상수                                                                      */
 /* -------------------------------------------------------------------------- */
-const PUBLIC_PATHS = [
-  '/_next',
-  '/favicon.ico',
-  '/fonts',
-  '/images',
-  '/icons',
-  '/test',
-];
+const PUBLIC_PATHS = ['/_next', '/favicon.ico', '/fonts', '/images', '/icons'];
 
 const ROLE_RESTRICTIONS = {
   ROLE_GUEST: {

--- a/src/utils/createFilterRequestParam.ts
+++ b/src/utils/createFilterRequestParam.ts
@@ -27,7 +27,6 @@ const CATEGORY_SETS: Record<
     '왓챠',
     '티빙',
     '쿠팡플레이',
-    '애플티비',
   ]),
   countries: new Set([
     '한국',

--- a/src/utils/getPlatformLogo.ts
+++ b/src/utils/getPlatformLogo.ts
@@ -3,8 +3,6 @@ export function getPlatformLogo(platform: string): string | undefined {
   switch (platform.toLowerCase()) {
     case '넷플릭스':
       return '/images/ott/netflix.webp';
-    case '애플티비':
-      return '/images/ott/appleTv.webp';
     case '티빙':
       return '/images/ott/tving.webp';
     case '디즈니+':


### PR DESCRIPTION
## #️⃣연관된 이슈 (없으면 비워두세요) -> 어떤 이슈를 해결한 건지 연관되는 이슈 번호 작성

> UDT-247

## 📝작업 내용

- AppleTV 컨텐츠 소멸에 따른 Explore페이지 필터, 설문조사 플랫폼 선택지, 개인 프로필 플랫폼 선택지에서 전부 AppleTV 삭제
- Constant, Component에서도 AppleTV 없애서 Type오류 방지

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
