### PR TITLE
[UDT-237] 콘텐츠 카테고리 지표 조회 API 연동 및 UI 수정 작업

### DIFF
--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -245,15 +245,18 @@ export default function AdminDashboard() {
             <ScrollArea className="h-[500px]">
               <div className="space-y-3 mb-3">
                 {allContents.map((content, idx) => (
-                  <ContentCard
-                    key={`${content.contentId}-${idx}`}
-                    content={content}
-                    onView={openDetailDialog}
-                    onEdit={openEditDialog}
-                    onDelete={handleDeleteContent}
-                  />
+                  <div key={content.contentId}>
+                    <ContentCard
+                      content={content}
+                      onView={openDetailDialog}
+                      onEdit={openEditDialog}
+                      onDelete={handleDeleteContent}
+                    />
+                    {idx === allContents.length - 8 && (
+                      <div ref={loadMoreRef} style={{ height: 1 }} />
+                    )}
+                  </div>
                 ))}
-                <div ref={loadMoreRef} style={{ height: 1 }} />
               </div>
             </ScrollArea>
             {isFetchingNextPage && (

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -28,11 +28,19 @@ import { useGetContentDetail } from '@hooks/admin/useGetContentDetail';
 import { useMutationErrorToast } from '@hooks/useMutationErrorToast';
 import ContentForm from '@components/admin/ContentForm';
 import ContentCard from '@components/admin/ContentCard';
-import ContentChart from '@components/admin/ContentChart';
+import CategoryChart from '@/components/admin/CategoryChart';
 import ContentDetail from '@components/admin/ContentDetail';
 import SearchFilter from '@components/admin/SearchFilter';
+import { useGetCategoryMetrics } from '@hooks/admin/useGetCategoryMetrics';
 
 export default function AdminDashboard() {
+  // 카테고리 지표 조회
+  const {
+    data: categoryMetricsData,
+    isLoading: isMetricsLoading,
+    error: metricsError,
+  } = useGetCategoryMetrics();
+
   // 무한 스크롤용 필터 상태
   const size = 20;
   const [categoryType, setCategoryType] = useState<string>('');
@@ -181,7 +189,15 @@ export default function AdminDashboard() {
         {/* 콘텐츠 분포 차트 */}
         <div className="w-full flex justify-center">
           <div className="w-full max-w-5xl">
-            <ContentChart contents={allContents} />
+            {isMetricsLoading ? (
+              <div className="text-center py-4">차트를 불러오는 중...</div>
+            ) : metricsError || !categoryMetricsData ? (
+              <div className="text-center py-4">카테고리 지표 로드 실패</div>
+            ) : (
+              <CategoryChart
+                categoryMetrics={categoryMetricsData.categoryMetrics}
+              />
+            )}
           </div>
         </div>
 

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -41,9 +41,20 @@ export default function AdminDashboard() {
     error: metricsError,
   } = useGetCategoryMetrics();
 
+  const [categoryType, setCategoryType] = useState<string>('');
+
+  const filteredCategoryCount =
+    categoryType && categoryType !== 'all'
+      ? (categoryMetricsData?.categoryMetrics.find(
+          (metric) => metric.categoryType === categoryType,
+        )?.count ?? 0)
+      : (categoryMetricsData?.categoryMetrics.reduce(
+          (sum, metric) => sum + metric.count,
+          0,
+        ) ?? 0);
+
   // 무한 스크롤용 필터 상태
   const size = 20;
-  const [categoryType, setCategoryType] = useState<string>('');
 
   // 무한 스크롤 쿼리
   const { data, isError, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -210,7 +221,7 @@ export default function AdminDashboard() {
                   등록된 콘텐츠 목록
                 </CardTitle>
                 <CardDescription>
-                  전체 {allContents.length}개의 콘텐츠
+                  전체 {filteredCategoryCount}개의 콘텐츠
                 </CardDescription>
               </div>
               <Button

--- a/src/components/admin/AdminDashboard.tsx
+++ b/src/components/admin/AdminDashboard.tsx
@@ -222,7 +222,7 @@ export default function AdminDashboard() {
             </div>
 
             {/* 검색 및 필터 */}
-            <div className="mt-4">
+            <div className="mt-1">
               <SearchFilter
                 filterType={categoryType}
                 onFilterChange={handleFilterChange}
@@ -231,7 +231,7 @@ export default function AdminDashboard() {
           </CardHeader>
 
           <CardContent>
-            <ScrollArea className="h-96">
+            <ScrollArea className="h-[500px]">
               <div className="space-y-3 mb-3">
                 {allContents.map((content, idx) => (
                   <ContentCard

--- a/src/components/admin/CategoryChart.tsx
+++ b/src/components/admin/CategoryChart.tsx
@@ -13,37 +13,34 @@ import {
   ChartTooltipContent,
 } from '@components/ui/chart';
 import { PieChart, Pie, Cell } from 'recharts';
-import { ContentSummary } from '@type/admin/Content';
-import { generateChartData } from '@utils/getContentUtils';
 import { CHART_COLORS } from '@/constants';
 import { useMemo } from 'react';
+import { CategoryMetric } from '@type/admin/CategoryMetric';
 
-interface ContenChartProps {
-  contents: ContentSummary[];
+interface CategoryChartProps {
+  categoryMetrics: CategoryMetric[];
 }
-
-export default function ContentChart({ contents }: ContenChartProps) {
-  const chartData = useMemo(() => generateChartData(contents), [contents]); // [{ name: '영화', value: 20 }, { name: '드라마', value: 10 }]
+export default function ContentChart({ categoryMetrics }: CategoryChartProps) {
+  const formattedData = useMemo(() => {
+    return categoryMetrics.map((item) => ({
+      name: item.categoryType,
+      count: item.count,
+      fill: CHART_COLORS[item.categoryId % CHART_COLORS.length],
+    }));
+  }, [categoryMetrics]);
 
   const chartConfig = useMemo(() => {
-    return chartData.reduce(
-      (acc, item, index) => {
-        acc[item.name] = {
-          label: item.name,
-          color: CHART_COLORS[index % CHART_COLORS.length],
+    return categoryMetrics.reduce(
+      (acc, item) => {
+        acc[item.categoryType] = {
+          label: item.categoryType,
+          color: CHART_COLORS[item.categoryId % CHART_COLORS.length],
         };
         return acc;
       },
       {} as Record<string, { label: string; color: string }>,
     );
-  }, [chartData]);
-
-  const formattedData = useMemo(() => {
-    return chartData.map((item, index) => ({
-      ...item,
-      fill: CHART_COLORS[index % CHART_COLORS.length],
-    }));
-  }, [chartData]);
+  }, [categoryMetrics]);
 
   return (
     <Card className="bg-white">
@@ -69,8 +66,8 @@ export default function ContentChart({ contents }: ContenChartProps) {
                 `${name} ${(percent * 100).toFixed(0)}%`
               }
             >
-              {formattedData.map((entry, index) => (
-                <Cell key={`cell-${index}`} fill={entry.fill} />
+              {formattedData.map((entry) => (
+                <Cell key={entry.name} fill={entry.fill} />
               ))}
             </Pie>
           </PieChart>

--- a/src/components/admin/ContentDetail.tsx
+++ b/src/components/admin/ContentDetail.tsx
@@ -98,7 +98,7 @@ export default function ContentDetail({
               </Card>
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <Card>
+                <Card className="min-h-[90px]">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 mt-3">
                       <Users className="h-5 w-5" />
@@ -138,7 +138,7 @@ export default function ContentDetail({
                   </CardContent>
                 </Card>
 
-                <Card>
+                <Card className="min-h-[90px]">
                   <CardHeader>
                     <CardTitle className="flex items-center gap-2 mt-3">
                       <Globe className="h-5 w-5" />
@@ -162,18 +162,22 @@ export default function ContentDetail({
                   <CardTitle className="mt-3">장르</CardTitle>
                 </CardHeader>
                 <CardContent>
+                  {/* 모든 카테고리 타입 표시 */}
                   <div className="flex flex-wrap gap-2 mb-3">
                     {content.categories.map((category, catIndex) => (
-                      <div key={catIndex} className="flex flex-wrap gap-1 mb-3">
-                        <Badge className="bg-blue-100 text-blue-800">
-                          {category.categoryType}
-                        </Badge>
-                        {category.genres.map((genre, genreIndex) => (
-                          <Badge key={genreIndex} variant="secondary">
-                            {genre}
-                          </Badge>
-                        ))}
-                      </div>
+                      <Badge
+                        key={catIndex}
+                        className="bg-blue-100 text-blue-800"
+                      >
+                        {category.categoryType}
+                      </Badge>
+                    ))}
+
+                    {/* 첫 번째 카테고리의 장르만 표시 */}
+                    {content.categories[0]?.genres.map((genre, genreIndex) => (
+                      <Badge key={genreIndex} variant="secondary">
+                        {genre}
+                      </Badge>
                     ))}
                   </div>
                 </CardContent>

--- a/src/components/admin/dialogs/actorSearchDialog.tsx
+++ b/src/components/admin/dialogs/actorSearchDialog.tsx
@@ -436,7 +436,8 @@ export default function CastSearchDialog({
                   <label className="text-sm font-medium mb-1 block">
                     프로필 이미지
                   </label>
-                  <div className="flex gap-2">
+                  {/* 버튼 + 미리보기 영역 */}
+                  <div className="flex gap-2 items-center">
                     <Input
                       type="file"
                       accept="image/*"
@@ -444,29 +445,30 @@ export default function CastSearchDialog({
                       className="hidden"
                       id="cast-image-upload"
                     />
+
                     <Button
                       type="button"
                       variant="outline"
                       onClick={() =>
                         document.getElementById('cast-image-upload')?.click()
                       }
-                      className="flex-1"
+                      className="flex-1 max-w-[160px]"
                     >
                       <Upload className="h-4 w-4 mr-2" />
                       이미지 업로드
                     </Button>
-                  </div>
-                  {newCast.castImageUrl && (
-                    <div className="mt-2">
+
+                    {/* 미리보기 이미지 */}
+                    {newCast.castImageUrl && (
                       <Image
                         src={newCast.castImageUrl || '/placeholder.svg'}
                         alt="미리보기"
-                        width={64}
-                        height={64}
-                        className="w-16 h-16 rounded-full object-cover"
+                        width={48}
+                        height={48}
+                        className="w-12 h-12 rounded-full object-cover"
                       />
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               </div>
 

--- a/src/components/admin/dialogs/directorSearchDialog.tsx
+++ b/src/components/admin/dialogs/directorSearchDialog.tsx
@@ -465,7 +465,7 @@ export default function DirectorSearchDialog({
                   <label className="text-sm font-medium mb-1 block">
                     프로필 이미지
                   </label>
-                  <div className="flex gap-2">
+                  <div className="flex gap-2 items-center">
                     <Input
                       type="file"
                       accept="image/*"
@@ -481,23 +481,22 @@ export default function DirectorSearchDialog({
                           .getElementById('director-image-upload')
                           ?.click()
                       }
-                      className="flex-1"
+                      className="flex-1 max-w-[160px]"
                     >
                       <Upload className="h-4 w-4 mr-2" />
                       이미지 업로드
                     </Button>
-                  </div>
-                  {newDirector.directorImageUrl && (
-                    <div className="mt-2">
+
+                    {newDirector.directorImageUrl && (
                       <Image
                         src={newDirector.directorImageUrl || '/placeholder.svg'}
                         alt="미리보기"
-                        width={64}
-                        height={64}
-                        className="w-16 h-16 rounded-full object-cover"
+                        width={48}
+                        height={48}
+                        className="w-12 h-12 rounded-full object-cover"
                       />
-                    </div>
-                  )}
+                    )}
+                  </div>
                 </div>
               </div>
 

--- a/src/hooks/admin/useGetCategoryMetrics.ts
+++ b/src/hooks/admin/useGetCategoryMetrics.ts
@@ -1,0 +1,12 @@
+import { getCategoryMetrics } from '@lib/apis/admin/getCategoryMetrics';
+import { useQuery } from '@tanstack/react-query';
+
+/**
+ * 콘텐츠 카테고리별 지표 조회 훅
+ */
+export const useGetCategoryMetrics = () => {
+  return useQuery({
+    queryKey: ['categoryMetrics'],
+    queryFn: getCategoryMetrics,
+  });
+};

--- a/src/lib/apis/admin/getCategoryMetrics.ts
+++ b/src/lib/apis/admin/getCategoryMetrics.ts
@@ -1,0 +1,12 @@
+import { CategoryMetricsResponse } from '@type/admin/CategoryMetric';
+import axiosInstance from '@lib/apis/axiosInstance';
+
+/**
+ * 콘텐츠 카테고리 별 지표 조회 API
+ * @returns 카테고리별 콘텐츠 수를 포함한 응답 객체
+ */
+export const getCategoryMetrics = () => {
+  return axiosInstance
+    .get<CategoryMetricsResponse>('/api/admin/metrics/categories')
+    .then((res) => res.data);
+};

--- a/src/types/admin/CategoryMetric.ts
+++ b/src/types/admin/CategoryMetric.ts
@@ -1,0 +1,9 @@
+export interface CategoryMetric {
+  categoryId: number;
+  categoryType: string;
+  count: number;
+}
+
+export interface CategoryMetricsResponse {
+  categoryMetrics: CategoryMetric[];
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

UDT-237-feat/content-category-metrics-api

## 📝작업 내용

API 연동

콘텐츠 카테고리 지표 조회 /api/admin/metrics/categories 연동
- 각 카테고리별 콘텐츠 갯수를 반영한 카테고리 분포 차트로 수정 CategoryChart
- 선택 필터에 따라 카테고리별 전체 콘텐츠 갯수 동적으로 표시 

UI 수정
- 콘텐츠 목록 높이 늘림
- idx === allContents.length - 8 조건으로 8개 이전 요소에 observer를 설정하여 무한 스크롤 매끄럽게 되도록 수정
- actorsearchdialog, directorsearchdialog 에서 감독, 배우 새로 등록 시 업로드 버튼 우측에 미리보기 사진 뜨도록 위치 수정
- 감독이 없는 경우 제작국가 div가 짤려 최소 height 추가 

버그 수정
- 카테고리가 여러개 일 때 장르가 중복되게 나오는 문제 해결 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> Reviewer가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

## ✅ 체크리스트

- [x] 코드가 정상적으로 동작함
- [x] UI/UX가 일관됨
- [x] 관련 테스트가 추가됨
- [x] 이슈에 연결되었음 (ex. Close #123)
